### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/html5_parser/input_stream.rs
+++ b/src/html5_parser/input_stream.rs
@@ -531,7 +531,7 @@ mod test {
                 col: 4
             }
         );
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
         assert_eq!(
             is.position,
             Position {
@@ -540,7 +540,7 @@ mod test {
                 col: 4
             }
         );
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
         assert_eq!(
             is.position,
             Position {
@@ -675,13 +675,13 @@ mod test {
         assert_eq!(is.read_char().utf8(), 'c');
         assert_eq!(is.read_char().utf8(), 'd');
         assert_eq!(is.chars_left(), 0);
-        assert_eq!(is.eof(), true);
+        assert!(is.eof());
 
         is.reset();
         assert_eq!(is.look_ahead(0).utf8(), 'a');
         assert_eq!(is.look_ahead(3).utf8(), 'c');
         assert_eq!(is.look_ahead(1).utf8(), 'b');
-        assert_eq!(is.look_ahead(100).is_eof(), true);
+        assert!(is.look_ahead(100).is_eof());
 
         is.seek(SeekMode::SeekSet, 0);
         assert_eq!(is.look_ahead_slice(1), "a");
@@ -733,19 +733,19 @@ mod test {
         assert_eq!(is.read_char().utf8(), 'a');
         assert_eq!(is.read_char().utf8(), 'b');
         assert_eq!(is.read_char().utf8(), 'c');
-        assert_eq!(is.read_char().is_eof(), true);
-        assert_eq!(is.read_char().is_eof(), true);
-        assert_eq!(is.read_char().is_eof(), true);
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
+        assert!(is.read_char().is_eof());
+        assert!(is.read_char().is_eof());
+        assert!(is.read_char().is_eof());
         is.unread();
-        assert_eq!(is.read_char().is_eof(), true);
-        is.unread();
-        is.unread();
-        assert_eq!(is.read_char().is_eof(), false);
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
         is.unread();
         is.unread();
-        assert_eq!(is.read_char().is_eof(), false);
+        assert!(!is.read_char().is_eof());
+        assert!(is.read_char().is_eof());
+        is.unread();
+        is.unread();
+        assert!(!is.read_char().is_eof());
         is.unread();
         is.unread();
         is.unread();
@@ -764,12 +764,12 @@ mod test {
         assert_eq!(is.read_char().utf8(), 'a');
         assert_eq!(is.read_char().utf8(), 'b');
         assert_eq!(is.read_char().utf8(), 'c');
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
         is.unread();
         is.unread();
         assert_eq!(is.read_char().utf8(), 'c');
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
         is.unread();
-        assert_eq!(is.read_char().is_eof(), true);
+        assert!(is.read_char().is_eof());
     }
 }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -309,7 +309,7 @@ mod test {
         let mut attributes = HashMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element("div", attributes, HTML_NAMESPACE);
-        assert_eq!(node.is_special(), true);
+        assert!(node.is_special());
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod test {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(element, attributes, HTML_NAMESPACE);
-            assert_eq!(node.is_special(), true);
+            assert!(node.is_special());
         }
     }
 
@@ -342,7 +342,7 @@ mod test {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(element, attributes, MATHML_NAMESPACE);
-            assert_eq!(node.is_special(), true);
+            assert!(node.is_special());
         }
     }
 
@@ -352,7 +352,7 @@ mod test {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
             let node = Node::new_element(element, attributes, SVG_NAMESPACE);
-            assert_eq!(node.is_special(), true);
+            assert!(node.is_special());
         }
     }
 


### PR DESCRIPTION
This PR adds a `rust-toolchain.toml` file to give future collaborators guidance on what version of Rust is intended.  While we're here, let's pick up some `clippy` linting issues.
