### PR TITLE
Fixup on construction active element algorithm

### DIFF
--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -54,9 +54,9 @@ fn main () -> io::Result<()> {
 
         let mut test_idx = 1;
         for test in tests {
-            // if test_idx == 23 {
+            if test_idx == 23 {
                 run_tree_test(test_idx, &test, &mut results);
-            // }
+            }
 
             test_idx += 1;
         }
@@ -151,7 +151,7 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
 
     // Check the document tree, which counts as a single assertion
     results.assertions += 1;
-    if match_document_tree(&document, &test.document) {
+    if match_document_tree(document, &test.document) {
         results.succeeded += 1;
     } else {
         results.failed += 1;
@@ -221,7 +221,7 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
             println!("{}", line);
         }
 
-        // exit(1);
+        std::process::exit(1);
     }
 
     println!("----------------------------------------");
@@ -301,5 +301,5 @@ fn match_error(got_err: &Error, expected_err: &Error) -> ErrorResult {
 
     // Found an error with the same code, but different line/pos
     println!("⚠️ Unexpected error position '{}' at {}:{} (got: {}:{})", expected_err.code, expected_err.line, expected_err.col, got_err.line, got_err.col);
-    return ErrorResult::PositionFailure;
+    ErrorResult::PositionFailure
 }

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -1,35 +1,35 @@
-use gosub_engine::html5_parser::input_stream::InputStream;
-use gosub_engine::html5_parser::node::NodeData;
-use gosub_engine::html5_parser::parser::document::Document;
-use gosub_engine::html5_parser::parser::Html5Parser;
-use regex::Regex;
+use std::{env, fs, io};
 use std::fs::File;
+use regex::Regex;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
-use std::{env, fs, io};
+use gosub_engine::html5_parser::input_stream::InputStream;
+use gosub_engine::html5_parser::node::NodeData;
+use gosub_engine::html5_parser::parser::Html5Parser;
+use gosub_engine::html5_parser::parser::document::Document;
 
-pub struct TestResults {
-    tests: usize,           // Number of tests (as defined in the suite)
-    assertions: usize, // Number of assertions (different combinations of input/output per test)
-    succeeded: usize,  // How many succeeded assertions
-    failed: usize,     // How many failed assertions
-    failed_position: usize, // How many failed assertions where position is not correct
+pub struct TestResults{
+    tests: usize,               // Number of tests (as defined in the suite)
+    assertions: usize,          // Number of assertions (different combinations of input/output per test)
+    succeeded: usize,           // How many succeeded assertions
+    failed: usize,              // How many failed assertions
+    failed_position: usize,     // How many failed assertions where position is not correct
 }
 
 struct Test {
-    file_path: String,              // Filename of the test
-    line: usize,                    // Line number of the test
-    data: String,                   // input stream
-    errors: Vec<Error>,             // errors
-    document: Vec<String>,          // document tree
-    document_fragment: Vec<String>, // fragment
+    file_path: String,                  // Filename of the test
+    line: usize,                        // Line number of the test
+    data: String,                       // input stream
+    errors: Vec<Error>,                 // errors
+    document: Vec<String>,              // document tree
+    document_fragment: Vec<String>,     // fragment
 }
 
-fn main() -> io::Result<()> {
+fn main () -> io::Result<()> {
     let default_dir = "./html5lib-tests";
     let dir = env::args().nth(1).unwrap_or(default_dir.to_string());
 
-    let mut results = TestResults {
+    let mut results = TestResults{
         tests: 0,
         assertions: 0,
         succeeded: 0,
@@ -41,7 +41,7 @@ fn main() -> io::Result<()> {
         let entry = entry?;
         let path = entry.path();
 
-        if !path.ends_with("tests1.dat") {
+        if ! path.ends_with("tests1.dat") {
             continue;
         }
 
@@ -54,8 +54,8 @@ fn main() -> io::Result<()> {
 
         let mut test_idx = 1;
         for test in tests {
-            // if test_idx == 3 {
-            run_tree_test(test_idx, &test, &mut results);
+            // if test_idx == 23 {
+                run_tree_test(test_idx, &test, &mut results);
             // }
 
             test_idx += 1;
@@ -81,21 +81,18 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     };
     let mut section: Option<&str> = None;
 
-    for (line_num, line) in reader.lines().enumerate() {
-        if line.is_err() {
-            continue;
-        }
-        let line = line.unwrap();
+    let mut line_num: usize = 0;
+    for line in reader.lines() {
+        line_num += 1;
+
+        let line = line?;
 
         if line.starts_with("#data") {
-            if !current_test.data.is_empty()
-                || !current_test.errors.is_empty()
-                || !current_test.document.is_empty()
-            {
+            if !current_test.data.is_empty() || !current_test.errors.is_empty() || !current_test.document.is_empty() {
                 current_test.data = current_test.data.trim_end().to_string();
                 tests.push(current_test);
-                current_test = Test {
-                    file_path: file_path.to_str().unwrap().to_string(),
+                current_test = Test{
+                    file_path: file_path.to_str().unwrap().clone().to_string(),
                     line: line_num,
                     data: "".to_string(),
                     errors: vec![],
@@ -120,9 +117,9 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
                         let col = caps.name("col").unwrap().as_str().parse::<i64>().unwrap();
                         let code = caps.name("code").unwrap().as_str().to_string();
 
-                        current_test.errors.push(Error { code, line, col });
+                        current_test.errors.push(Error{ code, line, col });
                     }
-                }
+                },
                 "document" => current_test.document.push(line),
                 "document_fragment" => current_test.document_fragment.push(line),
                 _ => (),
@@ -131,10 +128,7 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     }
 
     // Push the last test if it has data
-    if !current_test.data.is_empty()
-        || !current_test.errors.is_empty()
-        || !current_test.document.is_empty()
-    {
+    if !current_test.data.is_empty() || !current_test.errors.is_empty() || !current_test.document.is_empty() {
         current_test.data = current_test.data.trim_end().to_string();
         tests.push(current_test);
     }
@@ -142,11 +136,8 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     Ok(tests)
 }
 
-fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
-    println!(
-        "🧪 Running test #{}: {}::{}",
-        test_idx, test.file_path, test.line
-    );
+fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
+    println!("🧪 Running test #{}: {}::{}", test_idx, test.file_path, test.line);
 
     results.tests += 1;
 
@@ -156,12 +147,18 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
     is.read_from_str(test.data.as_str(), None);
 
     let mut parser = Html5Parser::new(&mut is);
-    let (document, _parse_errors) = parser.parse();
+    let (document, parse_errors) = parser.parse();
 
-    match_document_tree(document, &test.document);
+    // Check the document tree, which counts as a single assertion
+    results.assertions += 1;
+    if match_document_tree(&document, &test.document) {
+        results.succeeded += 1;
+    } else {
+        results.failed += 1;
+    }
 
-    // if parse_errors.len() != test.errors.len() {
-    //     println!("❌ Unexpected errors found (wanted {}, got {}): ", test.errors.len(), parse_errors.len());
+    if parse_errors.len() != test.errors.len() {
+         println!("❌ Unexpected errors found (wanted {}, got {}): ", test.errors.len(), parse_errors.len());
     //     for want_err in &test.errors {
     //         println!("     * Want: '{}' at {}:{}", want_err.code, want_err.line, want_err.col);
     //     }
@@ -170,9 +167,9 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
     //     }
     //     results.assertions += 1;
     //     results.failed += 1;
-    // } else {
-    //     println!("✅ Found {} errors", parse_errors.len());
-    // }
+    } else {
+         println!("✅ Found {} errors", parse_errors.len());
+    }
     //
     // // Check each error messages
     // let mut idx = 0;
@@ -210,6 +207,7 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
     //     idx += 1;
     // }
 
+
     if old_failed != results.failed {
         println!("----------------------------------------");
         println!("📄 Input stream: ");
@@ -222,17 +220,18 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
         for line in &test.document {
             println!("{}", line);
         }
+
+        // exit(1);
     }
 
     println!("----------------------------------------");
 }
 
-#[allow(dead_code)]
 #[derive(PartialEq)]
 enum ErrorResult {
-    Success,         // Found the correct error
-    Failure,         // Didn't find the error (not even with incorrect position)
-    PositionFailure, // Found the error, but on an incorrect position
+    Success,            // Found the correct error
+    Failure,            // Didn't find the error (not even with incorrect position)
+    PositionFailure,    // Found the error, but on an incorrect position
 }
 
 #[derive(PartialEq)]
@@ -242,67 +241,31 @@ pub struct Error {
     pub col: i64,
 }
 
-/**
--   Element nodes must be represented by a "`<`" then the *tag name
-    string* "`>`", and all the attributes must be given, sorted
-    lexicographically by UTF-16 code unit according to their *attribute
-    name string*, on subsequent lines, as if they were children of the
-    element node.
--   Attribute nodes must have the *attribute name string*, then an "="
-    sign, then the attribute value in double quotes (").
--   Text nodes must be the string, in double quotes. Newlines aren't
-    escaped.
--   Comments must be "`<`" then "`!-- `" then the data then "` -->`".
--   DOCTYPEs must be "`<!DOCTYPE `" then the name then if either of the
-    system id or public id is non-empty a space, public id in
-    double-quotes, another space an the system id in double-quotes, and
-    then in any case "`>`".
--   Processing instructions must be "`<?`", then the target, then a
-    space, then the data and then "`>`". (The HTML parser cannot emit
-    processing instructions, but scripts can, and the WebVTT to DOM
-    rules can emit them.)
--   Template contents are represented by the string "content" with the
-    children below it.
-**/
-
 fn match_document_tree(document: &Document, expected: &Vec<String>) -> bool {
-    match_node(0, -1, -1, document, expected);
-    true
+    match_node(0, -1, -1, document, expected).is_some()
 }
 
-fn match_node(
-    node_idx: usize,
-    expected_id: isize,
-    indent: isize,
-    document: &Document,
-    expected: &Vec<String>,
-) -> Option<usize> {
+fn match_node(node_idx: usize, expected_id: isize, indent: isize, document: &Document, expected: &Vec<String>) -> Option<usize> {
     let node = document.get_node_by_id(node_idx).unwrap();
 
     if node_idx > 0 {
         match &node.data {
             NodeData::Element { name, .. } => {
                 let value = format!("|{}<{}>", " ".repeat((indent as usize * 2) + 1), name);
-                if value != expected[expected_id as usize] {
-                    println!(
-                        "❌ {}, Found unexpected element node: {}",
-                        expected[expected_id as usize], name
-                    );
+                if value != expected[expected_id  as usize] {
+                    println!("❌ {}, Found unexpected element node: {}", expected[expected_id  as usize], name);
                     return None;
                 } else {
-                    println!("✅ {}", expected[expected_id as usize]);
+                    println!("✅ {}", expected[expected_id  as usize]);
                 }
             }
             NodeData::Text { value } => {
-                let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), value);
+                let value = format!("|{}\"{}\"", " ".repeat(indent  as usize * 2 + 1), value);
                 if value != expected[expected_id as usize] {
-                    println!(
-                        "❌ {}, Found unexpected text node: {}",
-                        expected[expected_id as usize], value
-                    );
+                    println!("❌ {}, Found unexpected text node: {}", expected[expected_id  as usize], value);
                     return None;
                 } else {
-                    println!("✅ {}", expected[expected_id as usize]);
+                    println!("✅ {}", expected[expected_id  as usize]);
                 }
             }
             _ => {}
@@ -312,9 +275,7 @@ fn match_node(
     let mut next_expected_idx = expected_id + 1;
 
     for &child_idx in &node.children {
-        if let Some(new_idx) =
-            match_node(child_idx, next_expected_idx, indent + 1, document, expected)
-        {
+        if let Some(new_idx)  = match_node(child_idx, next_expected_idx, indent + 1, document, expected) {
             next_expected_idx = new_idx as isize;
         } else {
             return None;
@@ -328,27 +289,17 @@ fn match_node(
 fn match_error(got_err: &Error, expected_err: &Error) -> ErrorResult {
     if got_err == expected_err {
         // Found an exact match
-        println!(
-            "✅ Found parse error '{}' at {}:{}",
-            got_err.code, got_err.line, got_err.col
-        );
+        println!("✅ Found parse error '{}' at {}:{}", got_err.code, got_err.line, got_err.col);
 
         return ErrorResult::Success;
     }
 
     if got_err.code != expected_err.code {
-        println!(
-            "❌ Expected error '{}' at {}:{}",
-            expected_err.code, expected_err.line, expected_err.col
-        );
+        println!("❌ Expected error '{}' at {}:{}", expected_err.code, expected_err.line, expected_err.col);
         return ErrorResult::Failure;
     }
 
     // Found an error with the same code, but different line/pos
-    println!(
-        "⚠️ Unexpected error position '{}' at {}:{} (got: {}:{})",
-        expected_err.code, expected_err.line, expected_err.col, got_err.line, got_err.col
-    );
-
-    ErrorResult::PositionFailure
+    println!("⚠️ Unexpected error position '{}' at {}:{} (got: {}:{})", expected_err.code, expected_err.line, expected_err.col, got_err.line, got_err.col);
+    return ErrorResult::PositionFailure;
 }

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -81,10 +81,7 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     };
     let mut section: Option<&str> = None;
 
-    let mut line_num: usize = 0;
-    for line in reader.lines() {
-        line_num += 1;
-
+    for (line_num, line) in reader.lines().enumerate() {
         let line = line?;
 
         if line.starts_with("#data") {

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -1,35 +1,35 @@
-use std::{env, fs, io};
-use std::fs::File;
-use regex::Regex;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
 use gosub_engine::html5_parser::input_stream::InputStream;
 use gosub_engine::html5_parser::node::NodeData;
-use gosub_engine::html5_parser::parser::Html5Parser;
 use gosub_engine::html5_parser::parser::document::Document;
+use gosub_engine::html5_parser::parser::Html5Parser;
+use regex::Regex;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::{env, fs, io};
 
-pub struct TestResults{
-    tests: usize,               // Number of tests (as defined in the suite)
-    assertions: usize,          // Number of assertions (different combinations of input/output per test)
-    succeeded: usize,           // How many succeeded assertions
-    failed: usize,              // How many failed assertions
-    failed_position: usize,     // How many failed assertions where position is not correct
+pub struct TestResults {
+    tests: usize,           // Number of tests (as defined in the suite)
+    assertions: usize, // Number of assertions (different combinations of input/output per test)
+    succeeded: usize,  // How many succeeded assertions
+    failed: usize,     // How many failed assertions
+    failed_position: usize, // How many failed assertions where position is not correct
 }
 
 struct Test {
-    file_path: String,                  // Filename of the test
-    line: usize,                        // Line number of the test
-    data: String,                       // input stream
-    errors: Vec<Error>,                 // errors
-    document: Vec<String>,              // document tree
-    document_fragment: Vec<String>,     // fragment
+    file_path: String,              // Filename of the test
+    line: usize,                    // Line number of the test
+    data: String,                   // input stream
+    errors: Vec<Error>,             // errors
+    document: Vec<String>,          // document tree
+    document_fragment: Vec<String>, // fragment
 }
 
-fn main () -> io::Result<()> {
+fn main() -> io::Result<()> {
     let default_dir = "./html5lib-tests";
     let dir = env::args().nth(1).unwrap_or(default_dir.to_string());
 
-    let mut results = TestResults{
+    let mut results = TestResults {
         tests: 0,
         assertions: 0,
         succeeded: 0,
@@ -41,7 +41,7 @@ fn main () -> io::Result<()> {
         let entry = entry?;
         let path = entry.path();
 
-        if ! path.ends_with("tests1.dat") {
+        if !path.ends_with("tests1.dat") {
             continue;
         }
 
@@ -85,10 +85,13 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
         let line = line?;
 
         if line.starts_with("#data") {
-            if !current_test.data.is_empty() || !current_test.errors.is_empty() || !current_test.document.is_empty() {
+            if !current_test.data.is_empty()
+                || !current_test.errors.is_empty()
+                || !current_test.document.is_empty()
+            {
                 current_test.data = current_test.data.trim_end().to_string();
                 tests.push(current_test);
-                current_test = Test{
+                current_test = Test {
                     file_path: file_path.to_str().unwrap().clone().to_string(),
                     line: line_num,
                     data: "".to_string(),
@@ -114,9 +117,9 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
                         let col = caps.name("col").unwrap().as_str().parse::<i64>().unwrap();
                         let code = caps.name("code").unwrap().as_str().to_string();
 
-                        current_test.errors.push(Error{ code, line, col });
+                        current_test.errors.push(Error { code, line, col });
                     }
-                },
+                }
                 "document" => current_test.document.push(line),
                 "document_fragment" => current_test.document_fragment.push(line),
                 _ => (),
@@ -125,7 +128,10 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     }
 
     // Push the last test if it has data
-    if !current_test.data.is_empty() || !current_test.errors.is_empty() || !current_test.document.is_empty() {
+    if !current_test.data.is_empty()
+        || !current_test.errors.is_empty()
+        || !current_test.document.is_empty()
+    {
         current_test.data = current_test.data.trim_end().to_string();
         tests.push(current_test);
     }
@@ -133,8 +139,11 @@ fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     Ok(tests)
 }
 
-fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
-    println!("🧪 Running test #{}: {}::{}", test_idx, test.file_path, test.line);
+fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
+    println!(
+        "🧪 Running test #{}: {}::{}",
+        test_idx, test.file_path, test.line
+    );
 
     results.tests += 1;
 
@@ -155,7 +164,11 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
     }
 
     if parse_errors.len() != test.errors.len() {
-         println!("❌ Unexpected errors found (wanted {}, got {}): ", test.errors.len(), parse_errors.len());
+        println!(
+            "❌ Unexpected errors found (wanted {}, got {}): ",
+            test.errors.len(),
+            parse_errors.len()
+        );
     //     for want_err in &test.errors {
     //         println!("     * Want: '{}' at {}:{}", want_err.code, want_err.line, want_err.col);
     //     }
@@ -165,7 +178,7 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
     //     results.assertions += 1;
     //     results.failed += 1;
     } else {
-         println!("✅ Found {} errors", parse_errors.len());
+        println!("✅ Found {} errors", parse_errors.len());
     }
     //
     // // Check each error messages
@@ -204,7 +217,6 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
     //     idx += 1;
     // }
 
-
     if old_failed != results.failed {
         println!("----------------------------------------");
         println!("📄 Input stream: ");
@@ -226,9 +238,9 @@ fn run_tree_test(test_idx: usize,test: &Test, results: &mut TestResults) {
 
 #[derive(PartialEq)]
 enum ErrorResult {
-    Success,            // Found the correct error
-    Failure,            // Didn't find the error (not even with incorrect position)
-    PositionFailure,    // Found the error, but on an incorrect position
+    Success,         // Found the correct error
+    Failure,         // Didn't find the error (not even with incorrect position)
+    PositionFailure, // Found the error, but on an incorrect position
 }
 
 #[derive(PartialEq)]
@@ -242,27 +254,39 @@ fn match_document_tree(document: &Document, expected: &Vec<String>) -> bool {
     match_node(0, -1, -1, document, expected).is_some()
 }
 
-fn match_node(node_idx: usize, expected_id: isize, indent: isize, document: &Document, expected: &Vec<String>) -> Option<usize> {
+fn match_node(
+    node_idx: usize,
+    expected_id: isize,
+    indent: isize,
+    document: &Document,
+    expected: &Vec<String>,
+) -> Option<usize> {
     let node = document.get_node_by_id(node_idx).unwrap();
 
     if node_idx > 0 {
         match &node.data {
             NodeData::Element { name, .. } => {
                 let value = format!("|{}<{}>", " ".repeat((indent as usize * 2) + 1), name);
-                if value != expected[expected_id  as usize] {
-                    println!("❌ {}, Found unexpected element node: {}", expected[expected_id  as usize], name);
+                if value != expected[expected_id as usize] {
+                    println!(
+                        "❌ {}, Found unexpected element node: {}",
+                        expected[expected_id as usize], name
+                    );
                     return None;
                 } else {
-                    println!("✅ {}", expected[expected_id  as usize]);
+                    println!("✅ {}", expected[expected_id as usize]);
                 }
             }
             NodeData::Text { value } => {
-                let value = format!("|{}\"{}\"", " ".repeat(indent  as usize * 2 + 1), value);
+                let value = format!("|{}\"{}\"", " ".repeat(indent as usize * 2 + 1), value);
                 if value != expected[expected_id as usize] {
-                    println!("❌ {}, Found unexpected text node: {}", expected[expected_id  as usize], value);
+                    println!(
+                        "❌ {}, Found unexpected text node: {}",
+                        expected[expected_id as usize], value
+                    );
                     return None;
                 } else {
-                    println!("✅ {}", expected[expected_id  as usize]);
+                    println!("✅ {}", expected[expected_id as usize]);
                 }
             }
             _ => {}
@@ -272,7 +296,9 @@ fn match_node(node_idx: usize, expected_id: isize, indent: isize, document: &Doc
     let mut next_expected_idx = expected_id + 1;
 
     for &child_idx in &node.children {
-        if let Some(new_idx)  = match_node(child_idx, next_expected_idx, indent + 1, document, expected) {
+        if let Some(new_idx) =
+            match_node(child_idx, next_expected_idx, indent + 1, document, expected)
+        {
             next_expected_idx = new_idx as isize;
         } else {
             return None;
@@ -286,17 +312,26 @@ fn match_node(node_idx: usize, expected_id: isize, indent: isize, document: &Doc
 fn match_error(got_err: &Error, expected_err: &Error) -> ErrorResult {
     if got_err == expected_err {
         // Found an exact match
-        println!("✅ Found parse error '{}' at {}:{}", got_err.code, got_err.line, got_err.col);
+        println!(
+            "✅ Found parse error '{}' at {}:{}",
+            got_err.code, got_err.line, got_err.col
+        );
 
         return ErrorResult::Success;
     }
 
     if got_err.code != expected_err.code {
-        println!("❌ Expected error '{}' at {}:{}", expected_err.code, expected_err.line, expected_err.col);
+        println!(
+            "❌ Expected error '{}' at {}:{}",
+            expected_err.code, expected_err.line, expected_err.col
+        );
         return ErrorResult::Failure;
     }
 
     // Found an error with the same code, but different line/pos
-    println!("⚠️ Unexpected error position '{}' at {}:{} (got: {}:{})", expected_err.code, expected_err.line, expected_err.col, got_err.line, got_err.col);
+    println!(
+        "⚠️ Unexpected error position '{}' at {}:{} (got: {}:{})",
+        expected_err.code, expected_err.line, expected_err.col, got_err.line, got_err.col
+    );
     ErrorResult::PositionFailure
 }

--- a/src/bin/parser_test.rs
+++ b/src/bin/parser_test.rs
@@ -9,24 +9,35 @@ use std::path::PathBuf;
 use std::{env, fs, io};
 
 pub struct TestResults {
-    tests: usize,           // Number of tests (as defined in the suite)
-    assertions: usize, // Number of assertions (different combinations of input/output per test)
-    succeeded: usize,  // How many succeeded assertions
-    failed: usize,     // How many failed assertions
-    failed_position: usize, // How many failed assertions where position is not correct
+    /// Number of tests (as defined in the suite)
+    tests: usize,
+    /// Number of assertions (different combinations of input/output per test)
+    assertions: usize,
+    /// How many succeeded assertions
+    succeeded: usize,
+    /// How many failed assertions
+    failed: usize,
+    /// How many failed assertions where position is not correct
+    failed_position: usize,
 }
 
 struct Test {
-    file_path: String,              // Filename of the test
-    line: usize,                    // Line number of the test
-    data: String,                   // input stream
-    errors: Vec<Error>,             // errors
-    document: Vec<String>,          // document tree
-    document_fragment: Vec<String>, // fragment
+    /// Filename of the test
+    file_path: String,
+    /// Line number of the test
+    line: usize,
+    /// input stream
+    data: String,
+    /// errors
+    errors: Vec<Error>,
+    /// document tree
+    document: Vec<String>,
+    /// fragment
+    document_fragment: Vec<String>,
 }
 
 fn main() -> io::Result<()> {
-    let default_dir = "./html5lib-tests";
+    let default_dir = "./tests/data/html5lib-tests";
     let dir = env::args().nth(1).unwrap_or(default_dir.to_string());
 
     let mut results = TestResults {
@@ -41,10 +52,12 @@ fn main() -> io::Result<()> {
         let entry = entry?;
         let path = entry.path();
 
+        // Only run the tests1.dat file for now
         if !path.ends_with("tests1.dat") {
             continue;
         }
 
+        // Skip dirs and non-dat files
         if !path.is_file() || path.extension().unwrap() != "dat" {
             continue;
         }
@@ -54,10 +67,7 @@ fn main() -> io::Result<()> {
 
         let mut test_idx = 1;
         for test in tests {
-            if test_idx == 23 {
-                run_tree_test(test_idx, &test, &mut results);
-            }
-
+            run_tree_test(test_idx, &test, &mut results);
             test_idx += 1;
         }
     }
@@ -66,6 +76,7 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
+/// Read given tests file and extract all test data
 fn read_tests(file_path: PathBuf) -> io::Result<Vec<Test>> {
     let file = File::open(file_path.clone())?;
     let reader = BufReader::new(file);
@@ -149,6 +160,7 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
 
     let old_failed = results.failed;
 
+    // Do the actual parsing
     let mut is = InputStream::new();
     is.read_from_str(test.data.as_str(), None);
 
@@ -169,18 +181,23 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
             test.errors.len(),
             parse_errors.len()
         );
-    //     for want_err in &test.errors {
-    //         println!("     * Want: '{}' at {}:{}", want_err.code, want_err.line, want_err.col);
-    //     }
-    //     for got_err in &parse_errors {
-    //         println!("     * Got: '{}' at {}:{}", got_err.message, got_err.line, got_err.col);
-    //     }
-    //     results.assertions += 1;
-    //     results.failed += 1;
+
+        for want_err in &test.errors {
+            println!("     * Want: '{}' at {}:{}", want_err.code, want_err.line, want_err.col);
+        }
+        for got_err in &parse_errors {
+            println!("     * Got: '{}' at {}:{}", got_err.message, got_err.line, got_err.col);
+        }
+        results.assertions += 1;
+        results.failed += 1;
     } else {
         println!("✅ Found {} errors", parse_errors.len());
     }
-    //
+
+    // For now, we skip the tests that checks for errors as most of the errors do not match
+    // with the actual tests, as these errors as specific from html5lib. Either we reuse them
+    // or have some kind of mapping to our own errors if we decide to use our custom errors.
+
     // // Check each error messages
     // let mut idx = 0;
     // for error in &test.errors {
@@ -217,6 +234,7 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
     //     idx += 1;
     // }
 
+    // Display additional data if there a failure is found
     if old_failed != results.failed {
         println!("----------------------------------------");
         println!("📄 Input stream: ");
@@ -230,7 +248,8 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
             println!("{}", line);
         }
 
-        std::process::exit(1);
+        // // End at the first failure
+        // std::process::exit(1);
     }
 
     println!("----------------------------------------");
@@ -238,9 +257,12 @@ fn run_tree_test(test_idx: usize, test: &Test, results: &mut TestResults) {
 
 #[derive(PartialEq)]
 enum ErrorResult {
-    Success,         // Found the correct error
-    Failure,         // Didn't find the error (not even with incorrect position)
-    PositionFailure, // Found the error, but on an incorrect position
+    /// Found the correct error
+    Success,
+    /// Didn't find the error (not even with incorrect position)
+    Failure,
+    /// Found the error, but on an incorrect position
+    PositionFailure,
 }
 
 #[derive(PartialEq)]
@@ -251,6 +273,9 @@ pub struct Error {
 }
 
 fn match_document_tree(document: &Document, expected: &Vec<String>) -> bool {
+    // We need a better tree match system. Right now we match the tree based on the (debug) output
+    // of the tree. Instead, we should generate a document-tree from the expected output and compare
+    // it against the current generated tree.
     match_node(0, -1, -1, document, expected).is_some()
 }
 

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -52,9 +52,7 @@ impl Node {
     // This will only compare against the tag, namespace and attributes. Both nodes could still have
     // other parents and children.
     pub fn matches_tag_and_attrs(&self, other: &Self) -> bool {
-        self.name == other.name &&
-        self.namespace == other.namespace &&
-        self.data == other.data
+        self.name == other.name && self.namespace == other.namespace && self.data == other.data
     }
 }
 

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -48,6 +48,16 @@ pub struct Node {
     pub data: NodeData,
 }
 
+impl Node {
+    // This will only compare against the tag, namespace and attributes. Both nodes could still have
+    // other parents and children.
+    pub fn matches_tag_and_attrs(&self, other: &Self) -> bool {
+        self.name == other.name &&
+        self.namespace == other.namespace &&
+        self.data == other.data
+    }
+}
+
 impl Clone for Node {
     fn clone(&self) -> Self {
         Node {

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -38,7 +38,7 @@ pub struct Node {
     pub id: usize,
     /// parent of the node, if any
     pub parent: Option<usize>,
-    /// children of the node
+    /// node IDs of the children of this node (if any)
     pub children: Vec<usize>,
     /// name of the node, or empty when it's not a tag
     pub name: String,
@@ -57,11 +57,12 @@ impl Node {
 }
 
 impl Clone for Node {
+    // Clones the node, but without the parent and children
     fn clone(&self) -> Self {
         Node {
             id: self.id,
-            parent: self.parent,
-            children: self.children.clone(),
+            parent: None,
+            children: vec![],
             name: self.name.clone(),
             namespace: self.namespace.clone(),
             data: self.data.clone(),
@@ -261,7 +262,7 @@ mod test {
         let node = Node::new_document();
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert_eq!(node.children, vec![] as Vec<usize>);
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(node.data, NodeData::Document {});
@@ -274,7 +275,7 @@ mod test {
         let node = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert_eq!(node.children, vec![] as Vec<usize>);
         assert_eq!(node.name, "div".to_string());
         assert_eq!(node.namespace, Some(HTML_NAMESPACE.into()));
         assert_eq!(
@@ -291,7 +292,7 @@ mod test {
         let node = Node::new_comment("test");
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert_eq!(node.children, vec![] as Vec<usize>);
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(
@@ -307,7 +308,7 @@ mod test {
         let node = Node::new_text("test");
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert_eq!(node.children, vec![] as Vec<usize>);
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -17,7 +17,12 @@ impl<'a> Html5Parser<'a> {
 
         // Step 2
         let current_node_id = current_node!(self).id;
-        if current_node!(self).name == *subject && ! self.active_formatting_elements.iter().any(|elem| elem == &ActiveElement::NodeId(current_node_id)) {
+        if current_node!(self).name == *subject
+            && !self
+                .active_formatting_elements
+                .iter()
+                .any(|elem| elem == &ActiveElement::NodeId(current_node_id))
+        {
             self.open_elements.pop();
             return;
         }
@@ -77,7 +82,9 @@ impl<'a> Html5Parser<'a> {
             }
 
             // Step 4.5
-            if open_elements_has!(self, formatting_element_name) && ! self.is_in_scope(&formatting_element_name, Scope::Regular) {
+            if open_elements_has!(self, formatting_element_name)
+                && !self.is_in_scope(&formatting_element_name, Scope::Regular)
+            {
                 self.parse_error("formatting element not in scope");
                 return;
             }
@@ -95,7 +102,7 @@ impl<'a> Html5Parser<'a> {
 
             for idx in (0..formatting_element_idx).rev() {
                 match self.active_formatting_elements[idx] {
-                    ActiveElement::Marker => {},
+                    ActiveElement::Marker => {}
                     ActiveElement::NodeId(node_id) => {
                         let node = self.document.get_node_by_id(node_id).unwrap();
                         if node.is_special() {
@@ -162,12 +169,19 @@ impl<'a> Html5Parser<'a> {
                 }
 
                 // Step 4.13.4
-                if inner_loop_counter > ADOPTION_AGENCY_INNER_LOOP_DEPTH && self.active_formatting_elements.contains(&ActiveElement::NodeId(node_id)) {
+                if inner_loop_counter > ADOPTION_AGENCY_INNER_LOOP_DEPTH
+                    && self
+                        .active_formatting_elements
+                        .contains(&ActiveElement::NodeId(node_id))
+                {
                     self.active_formatting_elements.remove(node_idx);
                 }
 
                 // Step 4.13.5
-                if ! self.active_formatting_elements.contains(&ActiveElement::NodeId(node_id)) {
+                if !self
+                    .active_formatting_elements
+                    .contains(&ActiveElement::NodeId(node_id))
+                {
                     // We have removed the node from the given node_idx
                     self.open_elements.remove(node_idx);
                     continue;
@@ -210,8 +224,10 @@ impl<'a> Html5Parser<'a> {
             let new_element_id = self.document.add_node(new_element, furthest_block_id);
 
             // Step 4.18
-            self.active_formatting_elements.remove(formatting_element_idx);
-            self.active_formatting_elements.insert(bookmark, ActiveElement::NodeId(new_element_id));
+            self.active_formatting_elements
+                .remove(formatting_element_idx);
+            self.active_formatting_elements
+                .insert(bookmark, ActiveElement::NodeId(new_element_id));
 
             // Step 4.19
             // Remove formatting element from the stack of open elements, and insert the new element into the stack of open elements immediately below the position of furthest block in that stack.

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -250,3 +250,30 @@ impl<'a> Html5Parser<'a> {
         replacement_node_id
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::html5_parser::input_stream::{Encoding, InputStream};
+    use super::*;
+
+    #[test]
+    fn test_adoption_agency() {
+        let mut stream = InputStream::new();
+        stream.read_from_str("<p>One <b>Two <i>Three</p> Four</i> Five</b> Six</p>", Some(Encoding::UTF8));
+        let mut parser = Html5Parser::new(&mut stream);
+        parser.parse();
+
+        println!("{}", parser.document);
+        // let document = parser.document;
+        // let table = document.get_node_by_id(1).unwrap();
+        // let tr = document.get_node_by_id(2).unwrap();
+        // let td = document.get_node_by_id(3).unwrap();
+        // let select = document.get_node_by_id(4).unwrap();
+        // let option = document.get_node_by_id(5).unwrap();
+        //
+        // assert_eq!(table.children, vec![tr.id]);
+        // assert_eq!(tr.children, vec![td.id]);
+        // assert_eq!(td.children, vec![select.id]);
+        // assert_eq!(select.children, vec![option.id]);
+    }
+}

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -29,7 +29,7 @@ impl<'a> Html5Parser<'a> {
                 .any(|elem| elem == &ActiveElement::NodeId(current_node_id))
         {
             self.open_elements.pop();
-            return AdoptionResult::Completed
+            return AdoptionResult::Completed;
         }
 
         // Step 3
@@ -39,7 +39,7 @@ impl<'a> Html5Parser<'a> {
         loop {
             // Step 4.1
             if outer_loop_counter >= ADOPTION_AGENCY_OUTER_LOOP_DEPTH {
-                return AdoptionResult::Completed
+                return AdoptionResult::Completed;
             }
 
             // Step 4.2
@@ -48,12 +48,19 @@ impl<'a> Html5Parser<'a> {
             // Step 4.3
             let formatting_element_idx = self.find_formatting_element(subject);
             if formatting_element_idx.is_none() {
-                return AdoptionResult::ProcessAsAnyOther
+                return AdoptionResult::ProcessAsAnyOther;
             }
 
-            let formatting_element_idx = formatting_element_idx.expect("formatting element not found");
-            let formatting_element_id = self.active_formatting_elements[formatting_element_idx].node_id().expect("formatting element not found");
-            let formatting_element_node= self.document.get_node_by_id(formatting_element_id).expect("formatting element not found").clone();
+            let formatting_element_idx =
+                formatting_element_idx.expect("formatting element not found");
+            let formatting_element_id = self.active_formatting_elements[formatting_element_idx]
+                .node_id()
+                .expect("formatting element not found");
+            let formatting_element_node = self
+                .document
+                .get_node_by_id(formatting_element_id)
+                .expect("formatting element not found")
+                .clone();
 
             // Step 4.4
             if !open_elements_has_id!(self, formatting_element_id) {
@@ -61,12 +68,11 @@ impl<'a> Html5Parser<'a> {
                 self.active_formatting_elements
                     .remove(formatting_element_idx);
 
-                return AdoptionResult::Completed
+                return AdoptionResult::Completed;
             }
 
             // Step 4.5
-            if !self.is_in_scope(&formatting_element_node.name, Scope::Regular)
-            {
+            if !self.is_in_scope(&formatting_element_node.name, Scope::Regular) {
                 self.parse_error("formatting element not in scope");
                 return AdoptionResult::Completed;
             }
@@ -93,20 +99,34 @@ impl<'a> Html5Parser<'a> {
                 }
 
                 // Remove the formatting element from the list of active formatting elements
-                if let Some(pos) = self.active_formatting_elements.iter().position(|elem| elem == &ActiveElement::NodeId(formatting_element_id)) {
+                if let Some(pos) = self
+                    .active_formatting_elements
+                    .iter()
+                    .position(|elem| elem == &ActiveElement::NodeId(formatting_element_id))
+                {
                     self.active_formatting_elements.remove(pos);
                 }
 
-                return AdoptionResult::Completed
+                return AdoptionResult::Completed;
             }
 
             let furthest_block_idx = furthest_block_idx.expect("furthest block not found");
 
-            let node_id = *self.open_elements.get(furthest_block_idx).expect("node not found");
-            let furthest_block = self.document.get_node_by_id(node_id).expect("node not found").clone();
+            let node_id = *self
+                .open_elements
+                .get(furthest_block_idx)
+                .expect("node not found");
+            let furthest_block = self
+                .document
+                .get_node_by_id(node_id)
+                .expect("node not found")
+                .clone();
 
             // Step 4.9
-            let common_ancestor_id = *self.open_elements.get(formatting_element_idx + 1).expect("node not found");
+            let common_ancestor_id = *self
+                .open_elements
+                .get(formatting_element_idx + 1)
+                .expect("node not found");
 
             // Step 4.10
             let mut bookmark = formatting_element_idx;
@@ -184,14 +204,12 @@ impl<'a> Html5Parser<'a> {
 
             // Step 4.15
             let new_element = match formatting_element_node.data {
-                NodeData::Element { ref attributes, .. } => {
-                     Node::new_element(
-                        formatting_element_node.name.as_str(),
-                        attributes.clone(),
-                        HTML_NAMESPACE,
-                    )
-                }
-                _ => panic!("formatting element is not an element")
+                NodeData::Element { ref attributes, .. } => Node::new_element(
+                    formatting_element_node.name.as_str(),
+                    attributes.clone(),
+                    HTML_NAMESPACE,
+                ),
+                _ => panic!("formatting element is not an element"),
             };
 
             // Step 4.16
@@ -211,7 +229,8 @@ impl<'a> Html5Parser<'a> {
             // Step 4.19
             // Remove formatting element from the stack of open elements, and insert the new element into the stack of open elements immediately below the position of furthest block in that stack.
             self.open_elements.remove(formatting_element_idx);
-            self.open_elements.insert(furthest_block_idx - 1, new_element_id);
+            self.open_elements
+                .insert(furthest_block_idx - 1, new_element_id);
         }
     }
 
@@ -251,7 +270,10 @@ impl<'a> Html5Parser<'a> {
         // Iterate
         for idx in (index_of_formatting_element..self.open_elements.len()).rev() {
             let element_id = self.open_elements[idx];
-            let element = self.document.get_node_by_id(element_id).expect("element not found");
+            let element = self
+                .document
+                .get_node_by_id(element_id)
+                .expect("element not found");
 
             if element.is_special() {
                 return Some(idx);
@@ -260,7 +282,6 @@ impl<'a> Html5Parser<'a> {
 
         None
     }
-
 
     // Find the formatting element with the given subject between the end of the list and the first marker (or start when there is no marker)
     fn find_formatting_element(&self, subject: &str) -> Option<usize> {
@@ -273,15 +294,15 @@ impl<'a> Html5Parser<'a> {
                 ActiveElement::Marker => {
                     // Marker found, do not continue
                     break;
-                },
+                }
                 ActiveElement::NodeId(node_id) => {
                     // Check if the given node is an element with the given subject
-                    let node = self.document.get_node_by_id(node_id).expect("node not found").clone();
-                    if let NodeData::Element {
-                        ref name,
-                        ..
-                    } = node.data
-                    {
+                    let node = self
+                        .document
+                        .get_node_by_id(node_id)
+                        .expect("node not found")
+                        .clone();
+                    if let NodeData::Element { ref name, .. } = node.data {
                         if name == subject {
                             return Some(idx);
                         }

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -289,6 +289,8 @@ mod test {
         parser.parse();
 
         println!("{}", parser.document);
+
+        assert!(true);
         // let document = parser.document;
         // let table = document.get_node_by_id(1).unwrap();
         // let tr = document.get_node_by_id(2).unwrap();

--- a/src/html5_parser/parser/adoption_agency.rs
+++ b/src/html5_parser/parser/adoption_agency.rs
@@ -290,7 +290,7 @@ mod test {
 
         println!("{}", parser.document);
 
-        assert!(true);
+        assert_eq!(true, true);
         // let document = parser.document;
         // let table = document.get_node_by_id(1).unwrap();
         // let tr = document.get_node_by_id(2).unwrap();

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -80,7 +80,7 @@ impl Document {
                 writeln!(f, "{}Document", prefix)?;
             }
             NodeData::Text { value } => {
-                writeln!(f, "{}{}", prefix, value)?;
+                writeln!(f, "{}\"{}\"", prefix, value)?;
             }
             NodeData::Comment { value } => {
                 writeln!(f, "{}<!-- {} -->", prefix, value)?;

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -97,6 +97,11 @@ impl Document {
             }
         }
 
+        if prefix.len() > 40 {
+            _ = writeln!(f, "...");
+            return;
+        }
+
         let mut buffer = prefix;
         if last {
             buffer.push_str("   ");

--- a/src/html5_parser/parser/document.rs
+++ b/src/html5_parser/parser/document.rs
@@ -69,44 +69,53 @@ impl Document {
 }
 
 impl Document {
-    fn display_tree(&self, node: &Node, indent: usize, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut prefix = " ".repeat(indent);
-        if !prefix.is_empty() {
-            prefix = format!("{}└─ ", prefix);
+    /// Print a node and all its children in a tree-like structure
+    pub fn print_tree(&self, node: &Node, prefix: String, last: bool, f: &mut fmt::Formatter<'_>) {
+        let mut buffer = prefix.clone();
+        if last {
+            buffer.push_str("└─ ");
+        } else {
+            buffer.push_str("├─ ");
         }
 
         match &node.data {
             NodeData::Document => {
-                writeln!(f, "{}Document", prefix)?;
+                _ = writeln!(f, "{}Document", buffer);
             }
             NodeData::Text { value } => {
-                writeln!(f, "{}\"{}\"", prefix, value)?;
+                _ = writeln!(f, "{}\"{}\"", buffer, value);
             }
             NodeData::Comment { value } => {
-                writeln!(f, "{}<!-- {} -->", prefix, value)?;
+                _ = writeln!(f, "{}<!-- {} -->", buffer, value);
             }
             NodeData::Element { name, attributes } => {
-                write!(f, "{}<{}", prefix, name)?;
+                _ = write!(f, "{}<{}", buffer, name);
                 for (key, value) in attributes.iter() {
-                    write!(f, " {}={}", key, value)?;
+                    _ = write!(f, " {}={}", key, value);
                 }
-                writeln!(f, ">")?;
+                _ = writeln!(f, ">");
             }
         }
 
-        for child_id in &node.children {
-            if let Some(child) = self.arena.get_node(*child_id) {
-                self.display_tree(child, indent + 2, f)?;
-            }
+        let mut buffer = prefix;
+        if last {
+            buffer.push_str("   ");
+        } else {
+            buffer.push_str("│  ");
         }
 
-        Ok(())
+        let len = node.children.len();
+        for (i, child) in node.children.iter().enumerate() {
+            let child = self.arena.get_node(*child).expect("Child not found");
+            self.print_tree(child, buffer.clone(), i == len - 1, f);
+        }
     }
 }
 
 impl fmt::Display for Document {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.display_tree(self.get_root(), 0, f)
+        self.print_tree(self.get_root(), "".to_string(), true, f);
+        Ok(())
     }
 }
 

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -118,6 +118,13 @@ macro_rules! pop_until_any {
     };
 }
 
+// Remove the given node_id from the open elements stack
+macro_rules! open_elements_remove {
+    ($self:expr, $target_node_id: expr) => {
+        $self.open_elements.retain(|&node_id| node_id != $target_node_id);
+    };
+}
+
 // Pops the last element from the open elements, and panics if it is not $name
 macro_rules! pop_check {
     ($self:expr, $name:expr) => {
@@ -202,9 +209,19 @@ mod adoption_agency;
 // Active formatting elements, which could be a regular node(id), or a marker
 #[derive(PartialEq)]
 enum ActiveElement {
-    Node(usize),
+    NodeId(usize),
     Marker,
 }
+
+impl ActiveElement {
+    fn node_id(&self) -> Option<usize> {
+        match self {
+            ActiveElement::NodeId(id) => Some(*id),
+            _ => None,
+        }
+    }
+}
+
 
 // The main parser object
 pub struct Html5Parser<'a> {
@@ -225,12 +242,10 @@ pub struct Html5Parser<'a> {
     pending_table_character_tokens: Vec<char>, // Pending table character tokens
     ack_self_closing: bool, // Acknowledge self closing tags
     active_formatting_elements: Vec<ActiveElement>, // List of active formatting elements or markers
-    is_fragment_case: bool, // Is the current parsing a fragment case
-    document: Document,    // A reference to the document we are parsing
-    error_logger: Rc<RefCell<ErrorLogger>>, // Error logger
+    is_fragment_case: bool,                         // Is the current parsing a fragment case
+    document: Document,                             // A reference to the document we are parsing
+    error_logger: Rc<RefCell<ErrorLogger>>,         // Error logger, which is shared with the tokenizer
 }
-
-impl<'a> Html5Parser<'a> {}
 
 // Defines the scopes for in_scope()
 enum Scope {
@@ -286,6 +301,8 @@ impl<'a> Html5Parser<'a> {
             if self.current_token.is_eof() {
                 break;
             }
+
+            self.display_stack(&self.open_elements);
 
             // println!("Token: {}", self.current_token);
 
@@ -749,7 +766,7 @@ impl<'a> Html5Parser<'a> {
                         }
 
                         pop_until!(self, "caption");
-                        self.clear_active_formatting_elements_until_marker();
+                        self.active_formatting_elements_clear_until_marker();
 
                         self.insertion_mode = InsertionMode::InTable;
                     }
@@ -862,7 +879,7 @@ impl<'a> Html5Parser<'a> {
                 InsertionMode::InTableBody => {
                     match &self.current_token {
                         Token::StartTagToken { name, .. } if name == "tr" => {
-                            self.clear_stack_back_to_table_context();
+                            self.clear_stack_back_to_table_body_context();
 
                             self.insert_html_element(&self.current_token.clone());
 
@@ -873,7 +890,7 @@ impl<'a> Html5Parser<'a> {
                                 "th or td tag not allowed in in table body insertion mode",
                             );
 
-                            self.clear_stack_back_to_table_context();
+                            self.clear_stack_back_to_table_body_context();
 
                             let token = Token::StartTagToken {
                                 name: "tr".to_string(),
@@ -884,50 +901,39 @@ impl<'a> Html5Parser<'a> {
 
                             self.insertion_mode = InsertionMode::InRow;
                             self.reprocess_token = true;
-                        }
-                        Token::StartTagToken { name, .. }
-                            if name == "tbody" || name == "tfoot" || name == "thead" =>
-                        {
-                            if !self.in_scope(name, Scope::Table) {
+                        },
+                        Token::StartTagToken { name, .. } if name == "tbody" || name == "tfoot" || name == "thead" => {
+                            if ! self.is_in_scope(name, Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
                             }
 
-                            self.clear_stack_back_to_table_context();
+                            self.clear_stack_back_to_table_body_context();
                             self.open_elements.pop();
 
                             self.insertion_mode = InsertionMode::InTable;
-                        }
-                        Token::StartTagToken { name, .. }
-                            if ["caption", "col", "colgroup", "tbody", "tfoot", "thead"]
-                                .contains(&name.as_str()) =>
-                        {
-                            if !self.in_scope("tbody", Scope::Table)
-                                && !self.in_scope("tfoot", Scope::Table)
-                                && !self.in_scope("thead", Scope::Table)
-                            {
+                        },
+                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "tfoot", "thead"].contains(&name.as_str()) => {
+                            if ! self.is_in_scope("tbody", Scope::Table) && ! self.is_in_scope("tfoot", Scope::Table) && ! self.is_in_scope("thead", Scope::Table) {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
                             }
 
-                            self.clear_stack_back_to_table_context();
+                            self.clear_stack_back_to_table_body_context();
                             self.open_elements.pop();
 
                             self.insertion_mode = InsertionMode::InTable;
                             self.reprocess_token = true;
                         }
                         Token::EndTagToken { name, .. } if name == "table" => {
-                            if !self.in_scope("tbody", Scope::Table)
-                                && !self.in_scope("tfoot", Scope::Table)
-                                && !self.in_scope("thead", Scope::Table)
-                            {
+                            if ! self.is_in_scope("tbody", Scope::Table) && ! self.is_in_scope("tfoot", Scope::Table) && ! self.is_in_scope("thead", Scope::Table) {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 continue;
                             }
 
-                            self.clear_stack_back_to_table_context();
+                            self.clear_stack_back_to_table_body_context();
                             self.open_elements.pop();
 
                             self.insertion_mode = InsertionMode::InTable;
@@ -956,10 +962,10 @@ impl<'a> Html5Parser<'a> {
                             self.insert_html_element(&self.current_token.clone());
 
                             self.insertion_mode = InsertionMode::InCell;
-                            self.add_marker();
-                        }
+                            self.active_formatting_elements_push_marker();
+                        },
                         Token::EndTagToken { name, .. } if name == "tr" => {
-                            if !self.in_scope("tr", Scope::Table) {
+                            if ! self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("tr tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -970,13 +976,8 @@ impl<'a> Html5Parser<'a> {
 
                             self.insertion_mode = InsertionMode::InTableBody;
                         }
-                        Token::StartTagToken { name, .. }
-                            if [
-                                "caption", "col", "colgroup", "tbody", "tfoot", "thead", "tr",
-                            ]
-                            .contains(&name.as_str()) =>
-                        {
-                            if !self.in_scope("tr", Scope::Table) {
+                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "tfoot", "thead", "tr"].contains(&name.as_str()) => {
+                            if ! self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -989,7 +990,7 @@ impl<'a> Html5Parser<'a> {
                             self.reprocess_token = true;
                         }
                         Token::EndTagToken { name, .. } if name == "table" => {
-                            if !self.in_scope("tr", Scope::Table) {
+                         if ! self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("table tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -1001,16 +1002,14 @@ impl<'a> Html5Parser<'a> {
                             self.insertion_mode = InsertionMode::InTableBody;
                             self.reprocess_token = true;
                         }
-                        Token::EndTagToken { name, .. }
-                            if name == "tbody" || name == "tfoot" || name == "thead" =>
-                        {
-                            if !self.in_scope(name, Scope::Table) {
+                        Token::EndTagToken { name, .. } if name == "tbody" || name == "tfoot" || name == "thead" => {
+                            if ! self.is_in_scope(name, Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
                             }
 
-                            if !self.in_scope("tr", Scope::Table) {
+                            if ! self.is_in_scope("tr", Scope::Table) {
                                 // ignore token
                                 continue;
                             }
@@ -1043,10 +1042,8 @@ impl<'a> Html5Parser<'a> {
                         Token::StartTagToken { name, .. } if name == "th" || name == "td" => {
                             let token_name = name.clone();
 
-                            if !self.in_scope(name.as_str(), Scope::Table) {
-                                self.parse_error(
-                                    "th or td tag not allowed in in cell insertion mode",
-                                );
+                            if ! self.is_in_scope(name.as_str(), Scope::Table) {
+                                self.parse_error("th or td tag not allowed in in cell insertion mode");
                                 // ignore token
                                 continue;
                             }
@@ -1059,20 +1056,12 @@ impl<'a> Html5Parser<'a> {
 
                             pop_until!(self, token_name);
 
-                            self.clear_active_formatting_elements_until_marker();
+                            self.active_formatting_elements_clear_until_marker();
 
                             self.insertion_mode = InsertionMode::InRow;
-                        }
-                        Token::StartTagToken { name, .. }
-                            if [
-                                "caption", "col", "colgroup", "tbody", "td", "tfoot", "th",
-                                "thead", "tr",
-                            ]
-                            .contains(&name.as_str()) =>
-                        {
-                            if !self.in_scope("td", Scope::Table)
-                                && !self.in_scope("th", Scope::Table)
-                            {
+                        },
+                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead", "tr"].contains(&name.as_str()) => {
+                            if ! self.is_in_scope("td", Scope::Table) && ! self.is_in_scope("th", Scope::Table) {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in cell insertion mode");
                                 // ignore token (fragment case?)
                                 continue;
@@ -1091,13 +1080,8 @@ impl<'a> Html5Parser<'a> {
                             self.parse_error("end tag not allowed in in cell insertion mode");
                             // ignore token
                         }
-                        Token::EndTagToken { name, .. }
-                            if name == "tbody"
-                                || name == "tfoot"
-                                || name == "thead"
-                                || name == "tr" =>
-                        {
-                            if !self.in_scope(name.as_str(), Scope::Table) {
+                        Token::EndTagToken { name, .. } if name == "table" || name == "tbody" || name == "tfoot" || name == "thead" || name == "tr" => {
+                            if ! self.is_in_scope(name.as_str(), Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
@@ -1200,10 +1184,8 @@ impl<'a> Html5Parser<'a> {
                             }
                         }
                         Token::EndTagToken { name, .. } if name == "select" => {
-                            if !self.in_scope("select", Scope::Select) {
-                                self.parse_error(
-                                    "select end tag not allowed in in select insertion mode",
-                                );
+                            if !self.is_in_scope("select", Scope::Select) {
+                                self.parse_error("select end tag not allowed in in select insertion mode");
                                 // ignore token
                                 continue;
                             }
@@ -1214,7 +1196,7 @@ impl<'a> Html5Parser<'a> {
                         Token::StartTagToken { name, .. } if name == "select" => {
                             self.parse_error("select tag not allowed in in select insertion mode");
 
-                            if !self.in_scope("select", Scope::Select) {
+                            if !self.is_in_scope("select", Scope::Select) {
                                 // ignore token (fragment case?)
                                 continue;
                             }
@@ -1227,7 +1209,7 @@ impl<'a> Html5Parser<'a> {
                         {
                             self.parse_error("input, keygen or textarea tag not allowed in in select insertion mode");
 
-                            if !self.in_scope("select", Scope::Select) {
+                            if !self.is_in_scope("select", Scope::Select) {
                                 // ignore token (fragment case)
                                 continue;
                             }
@@ -1287,7 +1269,7 @@ impl<'a> Html5Parser<'a> {
                         {
                             self.parse_error("caption, table, tbody, tfoot, thead, tr, td or th tag not allowed in in select in table insertion mode");
 
-                            if !self.in_scope(name, Scope::Select) {
+                            if !self.is_in_scope(name, Scope::Select) {
                                 // ignore token
                                 continue;
                             }
@@ -1385,7 +1367,7 @@ impl<'a> Html5Parser<'a> {
                             self.parse_error("eof not allowed in in template insertion mode");
 
                             pop_until!(self, "template");
-                            self.clear_active_formatting_elements_until_marker();
+                            self.active_formatting_elements_clear_until_marker();
                             self.template_insertion_mode.pop();
                             self.reset_insertion_mode();
                             self.reprocess_token = true;
@@ -1591,7 +1573,7 @@ impl<'a> Html5Parser<'a> {
         )
     }
 
-    // Retrieve a list of all errors generated by the parser/tokenizer
+    // Retrieves a list of all errors generated by the parser/tokenizer
     pub fn get_parse_errors(&self) -> Vec<ParseError> {
         self.error_logger.borrow().get_errors().clone()
     }
@@ -1637,25 +1619,6 @@ impl<'a> Html5Parser<'a> {
 
     fn flush_pending_table_character_tokens(&self) {
         todo!()
-    }
-
-    // Clear the active formatting stack until we reach the first marker
-    fn clear_active_formatting_elements_until_marker(&mut self) {
-        loop {
-            let active_elem = self.active_formatting_elements.pop();
-            if active_elem.is_none() {
-                return;
-            }
-
-            if let ActiveElement::Marker = active_elem.unwrap() {
-                return;
-            }
-        }
-    }
-
-    // Adds a marker to the active formatting stack
-    fn add_marker(&mut self) {
-        self.active_formatting_elements.push(ActiveElement::Marker);
     }
 
     // This function will pop elements off the stack until it reaches the first element that matches
@@ -1790,10 +1753,18 @@ impl<'a> Html5Parser<'a> {
 
     // Pop all elements back to a table context
     fn clear_stack_back_to_table_context(&mut self) {
-        while !self.open_elements.is_empty() {
-            if ["tbody", "tfoot", "thead", "template", "html"]
-                .contains(&current_node!(self).name.as_str())
-            {
+        while self.open_elements.len() > 0 {
+            if ["table", "template", "html"].contains(&current_node!(self).name.as_str()) {
+                return;
+            }
+            self.open_elements.pop();
+        }
+    }
+
+    // Pop all elements back to a table context
+    fn clear_stack_back_to_table_body_context(&mut self) {
+        while self.open_elements.len() > 0 {
+            if ["tbody", "tfoot", "thead", "template", "html"].contains(&current_node!(self).name.as_str()) {
                 return;
             }
             self.open_elements.pop();
@@ -1812,7 +1783,7 @@ impl<'a> Html5Parser<'a> {
     }
 
     // Checks if the given element is in given scope
-    fn in_scope(&self, tag: &str, scope: Scope) -> bool {
+    fn is_in_scope(&self, tag: &str, scope: Scope) -> bool {
         let mut idx = self.open_elements.len() - 1;
         loop {
             let node = open_elements_get!(self, idx);
@@ -1875,15 +1846,15 @@ impl<'a> Html5Parser<'a> {
         let tag = current_node!(self).name.clone();
         if tag != "td" && tag != "th" {
             self.parse_error("current node should be td or th");
-            return;
         }
 
         pop_until_any!(self, ["td", "th"]);
 
-        self.clear_active_formatting_elements_until_marker();
+        self.active_formatting_elements_clear_until_marker();
         self.insertion_mode = InsertionMode::InRow;
     }
 
+    // Handle insertion mode "in_body"
     fn handle_in_body(&mut self) {
         let mut any_other_end_tag = false;
 
@@ -1924,11 +1895,6 @@ impl<'a> Html5Parser<'a> {
                     return;
                 }
 
-                if self.open_elements.is_empty() {
-                    // ignore token
-                    return;
-                }
-
                 // Add attributes to html element
                 if let NodeData::Element {
                     attributes: node_attributes,
@@ -1962,6 +1928,24 @@ impl<'a> Html5Parser<'a> {
             Token::StartTagToken { name, .. } if name == "body" => {
                 self.parse_error("body tag not allowed in in body insertion mode");
 
+                if self.open_elements.len() > 1 || open_elements_get!(self, 1).name != "body" {
+                    // ignore token
+                    return;
+                }
+
+                if open_elements_has!(self, "template") {
+                    // ignore token
+                    return;
+                }
+
+                self.frameset_ok = false;
+
+                // Add attributes to body element
+                // @TODO add body attributes
+            },
+            Token::StartTagToken { name, .. } if name == "frameset" => {
+                self.parse_error("frameset tag not allowed in in body insertion mode");
+
                 if self.open_elements.len() == 1 || open_elements_get!(self, 1).name != "body" {
                     // ignore token
                     return;
@@ -1972,16 +1956,15 @@ impl<'a> Html5Parser<'a> {
                     return;
                 }
 
-                // Remove second element from parent node if has obe
                 self.open_elements.remove(1);
 
-                // pop all notes from bottom stack, from the current node up to the html element
-                // insert html element for token
-                // switch insertion mode to inframeset
+                while current_node!(self).name != "html" {
+                    self.open_elements.pop();
+                }
+
+                self.insert_html_element(&self.current_token.clone());
+
                 self.insertion_mode = InsertionMode::InFrameset;
-            }
-            Token::StartTagToken { name, .. } if name == "frameset" => {
-                // parse error
             }
             Token::EofToken => {
                 if !self.template_insertion_mode.is_empty() {
@@ -1992,7 +1975,7 @@ impl<'a> Html5Parser<'a> {
                 }
             }
             Token::EndTagToken { name, .. } if name == "body" => {
-                if !self.in_scope("body", Scope::Regular) {
+                if !self.is_in_scope("body", Scope::Regular) {
                     self.parse_error("body end tag not in scope");
                     // ignore token
                     return;
@@ -2003,7 +1986,7 @@ impl<'a> Html5Parser<'a> {
                 self.insertion_mode = InsertionMode::AfterBody;
             }
             Token::EndTagToken { name, .. } if name == "html" => {
-                if !self.in_scope("body", Scope::Regular) {
+                if !self.is_in_scope("body", Scope::Regular) {
                     self.parse_error("body end tag not in scope");
                     // ignore token
                     return;
@@ -2013,48 +1996,28 @@ impl<'a> Html5Parser<'a> {
 
                 self.insertion_mode = InsertionMode::AfterBody;
                 self.reprocess_token = true;
-            }
-            Token::StartTagToken { name, .. }
-                if name == "address"
-                    || name == "article"
-                    || name == "aside"
-                    || name == "blockquote"
-                    || name == "center"
-                    || name == "details"
-                    || name == "dialog"
-                    || name == "dir"
-                    || name == "div"
-                    || name == "dl"
-                    || name == "fieldset"
-                    || name == "figcaption"
-                    || name == "figure"
-                    || name == "footer"
-                    || name == "header"
-                    || name == "hgroup"
-                    || name == "main"
-                    || name == "menu"
-                    || name == "nav"
-                    || name == "ol"
-                    || name == "p"
-                    || name == "section"
-                    || name == "summary"
-                    || name == "ul" =>
-            {
-                if self.in_scope("p", Scope::Button) {
+            },
+            Token::StartTagToken { name, .. } if name == "address" || name == "article" || name == "aside" || name == "blockquote" || name == "center" || name == "details" || name == "dialog" || name == "dir" || name == "div" || name == "dl" || name == "fieldset" || name == "figcaption" || name == "figure" || name == "footer" || name == "header" || name == "hgroup" || name == "main" || name == "menu" || name == "nav" || name == "ol" || name == "p" || name == "section" || name == "summary" || name == "ul" => {
+                if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
                 self.insert_html_element(&self.current_token.clone());
-            }
-            Token::StartTagToken { name, .. }
-                if name == "h1"
-                    || name == "h2"
-                    || name == "h3"
-                    || name == "h4"
-                    || name == "h5"
-                    || name == "h6" =>
-            {
-                if self.in_scope("p", Scope::Button) {
+            },
+            Token::StartTagToken { name, .. } if name == "h1" || name == "h2" || name == "h3" || name == "h4" || name == "h5" || name == "h6" => {
+                if self.is_in_scope("p", Scope::Button) {
+                    self.close_p_element();
+                }
+
+                if ["h1", "h2", "h3", "h4", "h5", "h6"].contains(&current_node!(self).name.as_str()) {
+                    self.parse_error("h1-h6 not allowed in in body insertion mode");
+                    self.open_elements.pop();
+                }
+
+                self.insert_html_element(&self.current_token.clone());
+            },
+            Token::StartTagToken { name, .. } if name == "pre" || name == "listing" => {
+                if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
@@ -2071,7 +2034,7 @@ impl<'a> Html5Parser<'a> {
                         // ignore token
                     }
 
-                    if self.in_scope("p", Scope::Button) {
+                    if self.is_in_scope("p", Scope::Button) {
                         self.close_p_element();
                     }
                 }
@@ -2081,38 +2044,32 @@ impl<'a> Html5Parser<'a> {
                     self.form_element = Some(node_id);
                 }
             }
-            Token::StartTagToken { name, .. } if name == "li" => {}
-            Token::StartTagToken { name, .. } if name == "plaintext" => {}
-            Token::StartTagToken { name, .. } if name == "button" => {}
-            Token::EndTagToken { name, .. }
-                if name == "address"
-                    || name == "article"
-                    || name == "aside"
-                    || name == "blockquote"
-                    || name == "button"
-                    || name == "center"
-                    || name == "details"
-                    || name == "dialog"
-                    || name == "dir"
-                    || name == "div"
-                    || name == "dl"
-                    || name == "fieldset"
-                    || name == "figcaption"
-                    || name == "figure"
-                    || name == "footer"
-                    || name == "header"
-                    || name == "hgroup"
-                    || name == "listing"
-                    || name == "main"
-                    || name == "menu"
-                    || name == "nav"
-                    || name == "ol"
-                    || name == "pre"
-                    || name == "section"
-                    || name == "summary"
-                    || name == "ul" =>
-            {
-                if !self.in_scope(name, Scope::Regular) {
+            Token::StartTagToken { name, .. } if name == "li" => {
+            }
+            Token::StartTagToken { name, .. } if name == "dd" || name == "dt" => {
+            }
+            Token::StartTagToken { name, .. } if name == "plaintext" => {
+                if self.is_in_scope("p", Scope::Button) {
+                    self.close_p_element();
+                }
+
+                self.insert_html_element(&self.current_token.clone());
+
+                self.tokenizer.state = State::PlaintextState;
+            }
+            Token::StartTagToken { name, .. } if name == "button" => {
+                if self.is_in_scope("button", Scope::Regular) {
+                    self.parse_error("button tag not allowed in in body insertion mode");
+                    self.generate_all_implied_end_tags(None, false);
+                    pop_until!(self, "button");
+                }
+
+                self.reconstruct_formatting();
+                self.insert_html_element(&self.current_token.clone());
+                self.frameset_ok = false;
+            }
+            Token::EndTagToken { name, .. } if name == "address" || name == "article" || name == "aside" || name == "blockquote" || name == "button" || name == "center" || name == "details" || name == "dialog" || name == "dir" || name == "div" || name == "dl" || name == "fieldset" || name == "figcaption" || name == "figure" || name == "footer" || name == "header" || name == "hgroup" || name == "listing" || name == "main" || name == "menu" || name == "nav" || name == "ol" || name == "pre" || name == "section" || name == "summary" || name == "ul" => {
+                if ! self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2132,7 +2089,7 @@ impl<'a> Html5Parser<'a> {
                     let node_id = self.form_element;
                     self.form_element = None;
 
-                    if node_id.is_none() || !self.in_scope(name, Scope::Regular) {
+                    if node_id.is_none() || !self.is_in_scope(name, Scope::Regular) {
                         self.parse_error("end tag not in scope");
                         // ignore token
                         return;
@@ -2150,7 +2107,7 @@ impl<'a> Html5Parser<'a> {
                         self.parse_error("end tag not at top of stack");
                     }
                 } else {
-                    if !self.in_scope(name, Scope::Regular) {
+                    if ! self.is_in_scope(name, Scope::Regular) {
                         self.parse_error("end tag not in scope");
                         // ignore token
                         return;
@@ -2167,7 +2124,7 @@ impl<'a> Html5Parser<'a> {
                 }
             }
             Token::EndTagToken { name, .. } if name == "p" => {
-                if !self.in_scope(name, Scope::Button) {
+                if ! self.is_in_scope(name, Scope::Button) {
                     self.parse_error("end tag not in scope");
 
                     self.insert_html_element(&self.current_token.clone());
@@ -2178,7 +2135,7 @@ impl<'a> Html5Parser<'a> {
                 self.close_p_element();
             }
             Token::EndTagToken { name, .. } if name == "li" => {
-                if !self.in_scope(name, Scope::ListItem) {
+                if ! self.is_in_scope(name, Scope::ListItem) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2193,7 +2150,7 @@ impl<'a> Html5Parser<'a> {
                 pop_until!(self, *name);
             }
             Token::EndTagToken { name, .. } if name == "dd" || name == "dt" => {
-                if !self.in_scope(name, Scope::Regular) {
+                if ! self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2207,21 +2164,13 @@ impl<'a> Html5Parser<'a> {
 
                 pop_until!(self, *name);
             }
-            Token::EndTagToken { name, .. }
-                if name == "h1"
-                    || name == "h2"
-                    || name == "h3"
-                    || name == "h4"
-                    || name == "h5"
-                    || name == "h6" =>
-            {
-                if !self.in_scope("h1", Scope::Regular)
-                    || !self.in_scope("h2", Scope::Regular)
-                    || !self.in_scope("h3", Scope::Regular)
-                    || !self.in_scope("h4", Scope::Regular)
-                    || !self.in_scope("h5", Scope::Regular)
-                    || !self.in_scope("h6", Scope::Regular)
-                {
+            Token::EndTagToken { name, .. } if name == "h1" || name == "h2" || name == "h3" || name == "h4" || name == "h5" || name == "h6" => {
+                if ! self.is_in_scope("h1", Scope::Regular) ||
+                    ! self.is_in_scope("h2", Scope::Regular) ||
+                    ! self.is_in_scope("h3", Scope::Regular) ||
+                    ! self.is_in_scope("h4", Scope::Regular) ||
+                    ! self.is_in_scope("h5", Scope::Regular) ||
+                    ! self.is_in_scope("h6", Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2240,24 +2189,22 @@ impl<'a> Html5Parser<'a> {
                 any_other_end_tag = true;
             }
             Token::StartTagToken { name, .. } if name == "a" => {
-                if let Some((idx, _)) = self
-                    .active_formatting_elements
-                    .iter()
-                    .enumerate()
-                    .rev()
-                    .find(|(_, elem)| elem == &&ActiveElement::Marker)
-                {
-                    self.parse_error("marker not in active formatting elements");
-                    self.active_formatting_elements.remove(idx);
+                match self.active_formatting_elements_has_until_marker("a") {
+                    Some(node_id) => {
+                        self.parse_error("a tag in active formatting elements");
+                        self.run_adoption_agency(&self.current_token.clone());
 
-                    // @TODO: more stuff todo here
+                        // Remove from lists if not done already by the adoption agency
+                        open_elements_remove!(self, node_id);
+                        self.active_formatting_elements_remove(node_id);
+                    }
+                    _ => {},
                 }
 
                 self.reconstruct_formatting();
 
                 let node_id = self.insert_html_element(&self.current_token.clone());
-                self.active_formatting_elements
-                    .push(ActiveElement::Node(node_id));
+                self.active_formatting_elements_push(node_id);
             }
             Token::StartTagToken { name, .. }
                 if name == "b"
@@ -2276,21 +2223,19 @@ impl<'a> Html5Parser<'a> {
                 self.reconstruct_formatting();
 
                 let node_id = self.insert_html_element(&self.current_token.clone());
-                self.active_formatting_elements
-                    .push(ActiveElement::Node(node_id));
+                self.active_formatting_elements_push(node_id);
             }
             Token::StartTagToken { name, .. } if name == "nobr" => {
                 self.reconstruct_formatting();
 
-                if self.in_scope("nobr", Scope::Regular) {
+                if self.is_in_scope("nobr", Scope::Regular) {
                     self.parse_error("nobr tag in scope");
                     self.run_adoption_agency(&self.current_token.clone());
                     self.reconstruct_formatting();
                 }
 
                 let node_id = self.insert_html_element(&self.current_token.clone());
-                self.active_formatting_elements
-                    .push(ActiveElement::Node(node_id));
+                self.active_formatting_elements_push(node_id);
             }
             Token::EndTagToken { name, .. }
                 if name == "a"
@@ -2317,13 +2262,11 @@ impl<'a> Html5Parser<'a> {
 
                 self.insert_html_element(&self.current_token.clone());
 
-                self.add_marker();
+                self.active_formatting_elements_push_marker();
                 self.frameset_ok = false;
             }
-            Token::EndTagToken { name, .. }
-                if name == "applet" || name == "marquee" || name == "object" =>
-            {
-                if !self.in_scope(name, Scope::Regular) {
+            Token::EndTagToken { name, .. } if name == "applet" || name == "marquee" || name == "object" => {
+                if ! self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2336,12 +2279,10 @@ impl<'a> Html5Parser<'a> {
                 }
 
                 pop_until!(self, *name);
-                self.clear_active_formatting_elements_until_marker();
+                self.active_formatting_elements_clear_until_marker();
             }
             Token::StartTagToken { name, .. } if name == "table" => {
-                if self.document.quirks_mode != QuirksMode::Quirks
-                    && self.in_scope("p", Scope::Button)
-                {
+                if self.document.quirks_mode != QuirksMode::Quirks && self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
@@ -2420,12 +2361,8 @@ impl<'a> Html5Parser<'a> {
 
                 acknowledge_closing_tag!(self, *is_self_closing);
             }
-            Token::StartTagToken {
-                name,
-                is_self_closing,
-                ..
-            } if name == "hr" => {
-                if self.in_scope("p", Scope::Button) {
+            Token::StartTagToken { name, is_self_closing, .. } if name == "hr" => {
+                if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
@@ -2461,7 +2398,7 @@ impl<'a> Html5Parser<'a> {
                 self.insertion_mode = InsertionMode::Text;
             }
             Token::StartTagToken { name, .. } if name == "xmp" => {
-                if self.in_scope("p", Scope::Button) {
+                if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
@@ -2511,7 +2448,7 @@ impl<'a> Html5Parser<'a> {
                 self.document.add_node(node, current_node!(self).id);
             }
             Token::StartTagToken { name, .. } if name == "rb" || name == "rtc" => {
-                if self.in_scope("ruby", Scope::Regular) {
+                if self.is_in_scope("ruby", Scope::Regular) {
                     self.generate_all_implied_end_tags(None, false);
                 }
 
@@ -2523,7 +2460,7 @@ impl<'a> Html5Parser<'a> {
                 self.document.add_node(node, current_node!(self).id);
             }
             Token::StartTagToken { name, .. } if name == "rp" || name == "rt" => {
-                if self.in_scope("ruby", Scope::Regular) {
+                if self.is_in_scope("ruby", Scope::Regular) {
                     self.generate_all_implied_end_tags(Some("rtc"), false);
                 }
 
@@ -2606,6 +2543,7 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
+    // Handle insertion mode "in_head"
     fn handle_in_head(&mut self) {
         let mut anything_else = false;
 
@@ -2670,7 +2608,7 @@ impl<'a> Html5Parser<'a> {
             }
             Token::StartTagToken { name, .. } if name == "template" => {
                 self.insert_html_element(&self.current_token.clone());
-                self.add_marker();
+                self.active_formatting_elements_push_marker();
                 self.frameset_ok = false;
                 self.insertion_mode = InsertionMode::InTemplate;
                 self.template_insertion_mode.push(InsertionMode::InTemplate);
@@ -2689,7 +2627,7 @@ impl<'a> Html5Parser<'a> {
                 }
 
                 pop_until!(self, "template");
-                self.clear_active_formatting_elements_until_marker();
+                self.active_formatting_elements_clear_until_marker();
                 self.template_insertion_mode.pop();
 
                 self.reset_insertion_mode();
@@ -2715,10 +2653,12 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
+    // Handle insertion mode "in_template"
     fn handle_in_template(&mut self) {
         todo!()
     }
 
+    // Handle insertion mode "in_table"
     fn handle_in_table(&mut self) {
         let mut anything_else = false;
 
@@ -2743,7 +2683,7 @@ impl<'a> Html5Parser<'a> {
             }
             Token::StartTagToken { name, .. } if name == "caption" => {
                 self.clear_stack_back_to_table_context();
-                self.add_marker();
+                self.active_formatting_elements_push_marker();
                 self.insert_html_element(&self.current_token.clone());
                 self.insertion_mode = InsertionMode::InCaption;
             }
@@ -2880,62 +2820,161 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
+    // Handle insertion mode "in_select"
     fn handle_in_select(&mut self) {
         todo!()
     }
 
-    fn reconstruct_formatting(&mut self) {
-        // 1.
-        if self.active_formatting_elements.is_empty() {
-            return;
+    // Returns true if the given tag if found in the active formatting elements list (until the first marker)
+    fn active_formatting_elements_has_until_marker(&self, tag: &str) -> Option<usize> {
+        if self.active_formatting_elements.len() == 0 {
+            return None;
         }
 
-        // 3.
-        let entry = self.active_formatting_elements.last().unwrap();
-
-        // 2.
-        match entry {
-            ActiveElement::Marker => return,
-            ActiveElement::Node(node_id) => {
-                let node = self.document.get_node_by_id(*node_id).unwrap();
-                if open_elements_has!(self, node.name) {
-                    return;
-                }
-            }
-        }
-
-        // 4. rewind:
-        let mut idx;
+        let mut idx = self.active_formatting_elements.len() - 1;
         loop {
-            idx = self.active_formatting_elements.len() - 1;
-            if idx == 0 {
-                // create element
-            }
-
-            idx -= 1;
-
-            match entry {
-                ActiveElement::Marker => break,
-                ActiveElement::Node(node_id) => {
-                    let node = self.document.get_node_by_id(*node_id).unwrap();
-                    if open_elements_has!(self, node.name) {
-                        break;
+            match self.active_formatting_elements[idx] {
+                ActiveElement::Marker => return None,
+                ActiveElement::NodeId(node_id) => {
+                    if self.document.get_node_by_id(node_id).expect("node_id").name == tag {
+                        return Some(node_id);
                     }
                 }
             }
+
+            if idx == 0 {
+                // Reached the beginning of the list
+                return None;
+            }
+
+            idx -= 1;
+        }
+    }
+
+    // Adds a marker to the active formatting stack
+    fn active_formatting_elements_push_marker(&mut self) {
+        self.active_formatting_elements.push(ActiveElement::Marker);
+    }
+
+    // Clear the active formatting stack until we reach the first marker
+    fn active_formatting_elements_clear_until_marker(&mut self) {
+        while let Some(active_elem) = self.active_formatting_elements.pop() {
+            if let ActiveElement::Marker = active_elem {
+                // Found the marker
+                return;
+            }
+        }
+    }
+
+    // Remove the given node_id from the active formatting elements list
+    fn active_formatting_elements_remove(&mut self, target_node_id: usize) {
+        self.active_formatting_elements.retain(|node_id| {
+            match node_id {
+                ActiveElement::NodeId(node_id) => {
+                    *node_id != target_node_id
+                },
+                _ => true,
+            }
+        });
+    }
+
+    // Push a node onto the active formatting stack, make sure only max 3 of them can be added (between markers)
+    fn active_formatting_elements_push(&mut self, node_id: usize) {
+        let mut idx = self.active_formatting_elements.len();
+        if idx == 0 {
+            self.active_formatting_elements.push(ActiveElement::NodeId(node_id));
+            return;
         }
 
-        // 7. advance
+        // Fetch the node we want to push, so we can compare
+        let element_node = self.document.get_node_by_id(node_id).expect("node id not found");
+
+        let mut found = 0;
         loop {
-            idx += 1;
-
-            // 8/9. Create
-            // replace shzzls
-
-            // 10. If entry for new element is not last entry, return to advance
-            if idx == self.active_formatting_elements.len() {
+            let active_elem = self.active_formatting_elements.get(idx - 1).expect("index out of bounds");
+            if let ActiveElement::Marker = active_elem {
+                // Don't continue after the last marker
                 break;
             }
+
+            // Fetch the node we want to compare with
+            let match_node = match active_elem {
+                ActiveElement::NodeId(node_id) => self.document.get_node_by_id(*node_id).expect("node id not found"),
+                ActiveElement::Marker => unreachable!(),
+            };
+            if match_node.matches_tag_and_attrs(element_node) {
+                // Noah's Ark clause: we only allow 3 (instead of 2) of each tag (between markers)
+                found += 1;
+                if found == 3 {
+                    // Remove the element from the list
+                    self.active_formatting_elements.remove(idx - 1);
+                    break;
+                }
+            }
+
+            if idx == 0 {
+                break;
+            }
+            idx -= 1;
+        }
+
+        self.active_formatting_elements.push(ActiveElement::NodeId(node_id));
+    }
+
+    fn reconstruct_formatting(&mut self) {
+        if self.active_formatting_elements.is_empty() {
+            return; // Nothing to reconstruct.
+        }
+
+        let mut entry_index = self.active_formatting_elements.len() - 1;
+
+        loop {
+            // Let entry be the last (most recently added) element in the list of active formatting elements.
+            let entry = &self.active_formatting_elements[entry_index];
+
+            // If it's a marker or in the stack of open elements, nothing to reconstruct.
+            if let ActiveElement::Marker = entry {
+                return;
+            }
+            if self.open_elements.contains(&entry.node_id().expect("node id not found")) {
+                return;
+            }
+
+            // Rewind
+            if entry_index == 0 {
+                break; // Go to 'create' step
+            }
+            entry_index -= 1;
+        }
+
+        loop {
+            // If we reach here, we're at the 'create' step.
+            entry_index += 1;
+            let current_entry = &self.active_formatting_elements[entry_index];
+
+            // Create new element for the token.
+            let new_element = self.create_new_element(/* the token for which entry was created */);
+            let active_element = ActiveElement::NodeId(new_element.id);
+
+            // Replace the entry with the new element.
+            self.active_formatting_elements[entry_index] = active_element;
+
+            // Check if it's the last in the list.
+            if entry_index == self.active_formatting_elements.len() - 1 {
+                break;
+            }
+        }
+    }
+
+    fn create_new_formatting_element(&mut self, idx: usize, node: &Node) {
+        match &node.data {
+            NodeData::Element { name, attributes } => {
+                let token = Token::StartTagToken { name: name.clone(), is_self_closing: false, attributes: attributes.clone() };
+                let node_id = self.insert_html_element(&token);
+
+                self.active_formatting_elements[idx] = ActiveElement::NodeId(node_id);
+            }
+            _ => {}
         }
     }
 
@@ -3029,12 +3068,24 @@ impl<'a> Html5Parser<'a> {
         node_id
     }
 
+    // Switch the parser and tokenizer to the RAWTEXT state
     fn parse_raw_data(&mut self) {
-        todo!()
+        self.insert_html_element(&self.current_token.clone());
+
+        self.tokenizer.state = State::RawTextState;
+
+        self.original_insertion_mode = self.insertion_mode;
+        self.insertion_mode = InsertionMode::Text;
     }
 
+    // Switch the parser and tokenizer to the RCDATA state
     fn parse_rcdata(&mut self) {
-        todo!()
+        self.insert_html_element(&self.current_token.clone());
+
+        self.tokenizer.state = State::RcDataState;
+
+        self.original_insertion_mode = self.insertion_mode;
+        self.insertion_mode = InsertionMode::Text;
     }
 
     fn adjusted_insert_location(&self, override_node: Option<&Node>) -> usize {
@@ -3077,5 +3128,14 @@ impl<'a> Html5Parser<'a> {
         }
 
         adjusted_insertion_location
+    }
+
+    fn display_stack(&self, stack: &Vec<usize>) {
+        println!("-- stack start --");
+        for node_id in stack {
+            let node = self.document.get_node_by_id(*node_id).unwrap();
+            println!("{}: {}", node.id, node.name);
+        }
+        println!("-- stack end --");
     }
 }

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -121,7 +121,9 @@ macro_rules! pop_until_any {
 // Remove the given node_id from the open elements stack
 macro_rules! open_elements_remove {
     ($self:expr, $target_node_id: expr) => {
-        $self.open_elements.retain(|&node_id| node_id != $target_node_id);
+        $self
+            .open_elements
+            .retain(|&node_id| node_id != $target_node_id);
     };
 }
 
@@ -222,7 +224,6 @@ impl ActiveElement {
     }
 }
 
-
 // The main parser object
 pub struct Html5Parser<'a> {
     tokenizer: Tokenizer<'a>,                       // tokenizer object
@@ -242,9 +243,9 @@ pub struct Html5Parser<'a> {
     pending_table_character_tokens: Vec<char>, // Pending table character tokens
     ack_self_closing: bool, // Acknowledge self closing tags
     active_formatting_elements: Vec<ActiveElement>, // List of active formatting elements or markers
-    is_fragment_case: bool,                         // Is the current parsing a fragment case
-    document: Document,                             // A reference to the document we are parsing
-    error_logger: Rc<RefCell<ErrorLogger>>,         // Error logger, which is shared with the tokenizer
+    is_fragment_case: bool, // Is the current parsing a fragment case
+    document: Document,    // A reference to the document we are parsing
+    error_logger: Rc<RefCell<ErrorLogger>>, // Error logger, which is shared with the tokenizer
 }
 
 // Defines the scopes for in_scope()
@@ -901,9 +902,11 @@ impl<'a> Html5Parser<'a> {
 
                             self.insertion_mode = InsertionMode::InRow;
                             self.reprocess_token = true;
-                        },
-                        Token::StartTagToken { name, .. } if name == "tbody" || name == "tfoot" || name == "thead" => {
-                            if ! self.is_in_scope(name, Scope::Table) {
+                        }
+                        Token::StartTagToken { name, .. }
+                            if name == "tbody" || name == "tfoot" || name == "thead" =>
+                        {
+                            if !self.is_in_scope(name, Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
@@ -913,9 +916,15 @@ impl<'a> Html5Parser<'a> {
                             self.open_elements.pop();
 
                             self.insertion_mode = InsertionMode::InTable;
-                        },
-                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "tfoot", "thead"].contains(&name.as_str()) => {
-                            if ! self.is_in_scope("tbody", Scope::Table) && ! self.is_in_scope("tfoot", Scope::Table) && ! self.is_in_scope("thead", Scope::Table) {
+                        }
+                        Token::StartTagToken { name, .. }
+                            if ["caption", "col", "colgroup", "tbody", "tfoot", "thead"]
+                                .contains(&name.as_str()) =>
+                        {
+                            if !self.is_in_scope("tbody", Scope::Table)
+                                && !self.is_in_scope("tfoot", Scope::Table)
+                                && !self.is_in_scope("thead", Scope::Table)
+                            {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
@@ -928,7 +937,10 @@ impl<'a> Html5Parser<'a> {
                             self.reprocess_token = true;
                         }
                         Token::EndTagToken { name, .. } if name == "table" => {
-                            if ! self.is_in_scope("tbody", Scope::Table) && ! self.is_in_scope("tfoot", Scope::Table) && ! self.is_in_scope("thead", Scope::Table) {
+                            if !self.is_in_scope("tbody", Scope::Table)
+                                && !self.is_in_scope("tfoot", Scope::Table)
+                                && !self.is_in_scope("thead", Scope::Table)
+                            {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 continue;
                             }
@@ -963,9 +975,9 @@ impl<'a> Html5Parser<'a> {
 
                             self.insertion_mode = InsertionMode::InCell;
                             self.active_formatting_elements_push_marker();
-                        },
+                        }
                         Token::EndTagToken { name, .. } if name == "tr" => {
-                            if ! self.is_in_scope("tr", Scope::Table) {
+                            if !self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("tr tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -976,8 +988,13 @@ impl<'a> Html5Parser<'a> {
 
                             self.insertion_mode = InsertionMode::InTableBody;
                         }
-                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "tfoot", "thead", "tr"].contains(&name.as_str()) => {
-                            if ! self.is_in_scope("tr", Scope::Table) {
+                        Token::StartTagToken { name, .. }
+                            if [
+                                "caption", "col", "colgroup", "tbody", "tfoot", "thead", "tr",
+                            ]
+                            .contains(&name.as_str()) =>
+                        {
+                            if !self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -990,7 +1007,7 @@ impl<'a> Html5Parser<'a> {
                             self.reprocess_token = true;
                         }
                         Token::EndTagToken { name, .. } if name == "table" => {
-                         if ! self.is_in_scope("tr", Scope::Table) {
+                            if !self.is_in_scope("tr", Scope::Table) {
                                 self.parse_error("table tag not allowed in in row insertion mode");
                                 // ignore token
                                 continue;
@@ -1002,14 +1019,16 @@ impl<'a> Html5Parser<'a> {
                             self.insertion_mode = InsertionMode::InTableBody;
                             self.reprocess_token = true;
                         }
-                        Token::EndTagToken { name, .. } if name == "tbody" || name == "tfoot" || name == "thead" => {
-                            if ! self.is_in_scope(name, Scope::Table) {
+                        Token::EndTagToken { name, .. }
+                            if name == "tbody" || name == "tfoot" || name == "thead" =>
+                        {
+                            if !self.is_in_scope(name, Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
                             }
 
-                            if ! self.is_in_scope("tr", Scope::Table) {
+                            if !self.is_in_scope("tr", Scope::Table) {
                                 // ignore token
                                 continue;
                             }
@@ -1042,8 +1061,10 @@ impl<'a> Html5Parser<'a> {
                         Token::StartTagToken { name, .. } if name == "th" || name == "td" => {
                             let token_name = name.clone();
 
-                            if ! self.is_in_scope(name.as_str(), Scope::Table) {
-                                self.parse_error("th or td tag not allowed in in cell insertion mode");
+                            if !self.is_in_scope(name.as_str(), Scope::Table) {
+                                self.parse_error(
+                                    "th or td tag not allowed in in cell insertion mode",
+                                );
                                 // ignore token
                                 continue;
                             }
@@ -1059,9 +1080,17 @@ impl<'a> Html5Parser<'a> {
                             self.active_formatting_elements_clear_until_marker();
 
                             self.insertion_mode = InsertionMode::InRow;
-                        },
-                        Token::StartTagToken { name, .. } if ["caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead", "tr"].contains(&name.as_str()) => {
-                            if ! self.is_in_scope("td", Scope::Table) && ! self.is_in_scope("th", Scope::Table) {
+                        }
+                        Token::StartTagToken { name, .. }
+                            if [
+                                "caption", "col", "colgroup", "tbody", "td", "tfoot", "th",
+                                "thead", "tr",
+                            ]
+                            .contains(&name.as_str()) =>
+                        {
+                            if !self.is_in_scope("td", Scope::Table)
+                                && !self.is_in_scope("th", Scope::Table)
+                            {
                                 self.parse_error("caption, col, colgroup, tbody, tfoot or thead tag not allowed in in cell insertion mode");
                                 // ignore token (fragment case?)
                                 continue;
@@ -1080,8 +1109,14 @@ impl<'a> Html5Parser<'a> {
                             self.parse_error("end tag not allowed in in cell insertion mode");
                             // ignore token
                         }
-                        Token::EndTagToken { name, .. } if name == "table" || name == "tbody" || name == "tfoot" || name == "thead" || name == "tr" => {
-                            if ! self.is_in_scope(name.as_str(), Scope::Table) {
+                        Token::EndTagToken { name, .. }
+                            if name == "table"
+                                || name == "tbody"
+                                || name == "tfoot"
+                                || name == "thead"
+                                || name == "tr" =>
+                        {
+                            if !self.is_in_scope(name.as_str(), Scope::Table) {
                                 self.parse_error("tbody, tfoot or thead tag not allowed in in table body insertion mode");
                                 // ignore token
                                 continue;
@@ -1185,7 +1220,9 @@ impl<'a> Html5Parser<'a> {
                         }
                         Token::EndTagToken { name, .. } if name == "select" => {
                             if !self.is_in_scope("select", Scope::Select) {
-                                self.parse_error("select end tag not allowed in in select insertion mode");
+                                self.parse_error(
+                                    "select end tag not allowed in in select insertion mode",
+                                );
                                 // ignore token
                                 continue;
                             }
@@ -1764,7 +1801,9 @@ impl<'a> Html5Parser<'a> {
     // Pop all elements back to a table context
     fn clear_stack_back_to_table_body_context(&mut self) {
         while !self.open_elements.is_empty() {
-            if ["tbody", "tfoot", "thead", "template", "html"].contains(&current_node!(self).name.as_str()) {
+            if ["tbody", "tfoot", "thead", "template", "html"]
+                .contains(&current_node!(self).name.as_str())
+            {
                 return;
             }
             self.open_elements.pop();
@@ -1942,7 +1981,7 @@ impl<'a> Html5Parser<'a> {
 
                 // Add attributes to body element
                 // @TODO add body attributes
-            },
+            }
             Token::StartTagToken { name, .. } if name == "frameset" => {
                 self.parse_error("frameset tag not allowed in in body insertion mode");
 
@@ -1996,26 +2035,59 @@ impl<'a> Html5Parser<'a> {
 
                 self.insertion_mode = InsertionMode::AfterBody;
                 self.reprocess_token = true;
-            },
-            Token::StartTagToken { name, .. } if name == "address" || name == "article" || name == "aside" || name == "blockquote" || name == "center" || name == "details" || name == "dialog" || name == "dir" || name == "div" || name == "dl" || name == "fieldset" || name == "figcaption" || name == "figure" || name == "footer" || name == "header" || name == "hgroup" || name == "main" || name == "menu" || name == "nav" || name == "ol" || name == "p" || name == "section" || name == "summary" || name == "ul" => {
+            }
+            Token::StartTagToken { name, .. }
+                if name == "address"
+                    || name == "article"
+                    || name == "aside"
+                    || name == "blockquote"
+                    || name == "center"
+                    || name == "details"
+                    || name == "dialog"
+                    || name == "dir"
+                    || name == "div"
+                    || name == "dl"
+                    || name == "fieldset"
+                    || name == "figcaption"
+                    || name == "figure"
+                    || name == "footer"
+                    || name == "header"
+                    || name == "hgroup"
+                    || name == "main"
+                    || name == "menu"
+                    || name == "nav"
+                    || name == "ol"
+                    || name == "p"
+                    || name == "section"
+                    || name == "summary"
+                    || name == "ul" =>
+            {
                 if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
                 self.insert_html_element(&self.current_token.clone());
-            },
-            Token::StartTagToken { name, .. } if name == "h1" || name == "h2" || name == "h3" || name == "h4" || name == "h5" || name == "h6" => {
+            }
+            Token::StartTagToken { name, .. }
+                if name == "h1"
+                    || name == "h2"
+                    || name == "h3"
+                    || name == "h4"
+                    || name == "h5"
+                    || name == "h6" =>
+            {
                 if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
 
-                if ["h1", "h2", "h3", "h4", "h5", "h6"].contains(&current_node!(self).name.as_str()) {
+                if ["h1", "h2", "h3", "h4", "h5", "h6"].contains(&current_node!(self).name.as_str())
+                {
                     self.parse_error("h1-h6 not allowed in in body insertion mode");
                     self.open_elements.pop();
                 }
 
                 self.insert_html_element(&self.current_token.clone());
-            },
+            }
             Token::StartTagToken { name, .. } if name == "pre" || name == "listing" => {
                 if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
@@ -2044,10 +2116,8 @@ impl<'a> Html5Parser<'a> {
                     self.form_element = Some(node_id);
                 }
             }
-            Token::StartTagToken { name, .. } if name == "li" => {
-            }
-            Token::StartTagToken { name, .. } if name == "dd" || name == "dt" => {
-            }
+            Token::StartTagToken { name, .. } if name == "li" => {}
+            Token::StartTagToken { name, .. } if name == "dd" || name == "dt" => {}
             Token::StartTagToken { name, .. } if name == "plaintext" => {
                 if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
@@ -2068,8 +2138,35 @@ impl<'a> Html5Parser<'a> {
                 self.insert_html_element(&self.current_token.clone());
                 self.frameset_ok = false;
             }
-            Token::EndTagToken { name, .. } if name == "address" || name == "article" || name == "aside" || name == "blockquote" || name == "button" || name == "center" || name == "details" || name == "dialog" || name == "dir" || name == "div" || name == "dl" || name == "fieldset" || name == "figcaption" || name == "figure" || name == "footer" || name == "header" || name == "hgroup" || name == "listing" || name == "main" || name == "menu" || name == "nav" || name == "ol" || name == "pre" || name == "section" || name == "summary" || name == "ul" => {
-                if ! self.is_in_scope(name, Scope::Regular) {
+            Token::EndTagToken { name, .. }
+                if name == "address"
+                    || name == "article"
+                    || name == "aside"
+                    || name == "blockquote"
+                    || name == "button"
+                    || name == "center"
+                    || name == "details"
+                    || name == "dialog"
+                    || name == "dir"
+                    || name == "div"
+                    || name == "dl"
+                    || name == "fieldset"
+                    || name == "figcaption"
+                    || name == "figure"
+                    || name == "footer"
+                    || name == "header"
+                    || name == "hgroup"
+                    || name == "listing"
+                    || name == "main"
+                    || name == "menu"
+                    || name == "nav"
+                    || name == "ol"
+                    || name == "pre"
+                    || name == "section"
+                    || name == "summary"
+                    || name == "ul" =>
+            {
+                if !self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2107,7 +2204,7 @@ impl<'a> Html5Parser<'a> {
                         self.parse_error("end tag not at top of stack");
                     }
                 } else {
-                    if ! self.is_in_scope(name, Scope::Regular) {
+                    if !self.is_in_scope(name, Scope::Regular) {
                         self.parse_error("end tag not in scope");
                         // ignore token
                         return;
@@ -2124,7 +2221,7 @@ impl<'a> Html5Parser<'a> {
                 }
             }
             Token::EndTagToken { name, .. } if name == "p" => {
-                if ! self.is_in_scope(name, Scope::Button) {
+                if !self.is_in_scope(name, Scope::Button) {
                     self.parse_error("end tag not in scope");
 
                     self.insert_html_element(&self.current_token.clone());
@@ -2135,7 +2232,7 @@ impl<'a> Html5Parser<'a> {
                 self.close_p_element();
             }
             Token::EndTagToken { name, .. } if name == "li" => {
-                if ! self.is_in_scope(name, Scope::ListItem) {
+                if !self.is_in_scope(name, Scope::ListItem) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2150,7 +2247,7 @@ impl<'a> Html5Parser<'a> {
                 pop_until!(self, *name);
             }
             Token::EndTagToken { name, .. } if name == "dd" || name == "dt" => {
-                if ! self.is_in_scope(name, Scope::Regular) {
+                if !self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2164,13 +2261,21 @@ impl<'a> Html5Parser<'a> {
 
                 pop_until!(self, *name);
             }
-            Token::EndTagToken { name, .. } if name == "h1" || name == "h2" || name == "h3" || name == "h4" || name == "h5" || name == "h6" => {
-                if ! self.is_in_scope("h1", Scope::Regular) ||
-                    ! self.is_in_scope("h2", Scope::Regular) ||
-                    ! self.is_in_scope("h3", Scope::Regular) ||
-                    ! self.is_in_scope("h4", Scope::Regular) ||
-                    ! self.is_in_scope("h5", Scope::Regular) ||
-                    ! self.is_in_scope("h6", Scope::Regular) {
+            Token::EndTagToken { name, .. }
+                if name == "h1"
+                    || name == "h2"
+                    || name == "h3"
+                    || name == "h4"
+                    || name == "h5"
+                    || name == "h6" =>
+            {
+                if !self.is_in_scope("h1", Scope::Regular)
+                    || !self.is_in_scope("h2", Scope::Regular)
+                    || !self.is_in_scope("h3", Scope::Regular)
+                    || !self.is_in_scope("h4", Scope::Regular)
+                    || !self.is_in_scope("h5", Scope::Regular)
+                    || !self.is_in_scope("h6", Scope::Regular)
+                {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2262,8 +2367,10 @@ impl<'a> Html5Parser<'a> {
                 self.active_formatting_elements_push_marker();
                 self.frameset_ok = false;
             }
-            Token::EndTagToken { name, .. } if name == "applet" || name == "marquee" || name == "object" => {
-                if ! self.is_in_scope(name, Scope::Regular) {
+            Token::EndTagToken { name, .. }
+                if name == "applet" || name == "marquee" || name == "object" =>
+            {
+                if !self.is_in_scope(name, Scope::Regular) {
                     self.parse_error("end tag not in scope");
                     // ignore token
                     return;
@@ -2279,7 +2386,9 @@ impl<'a> Html5Parser<'a> {
                 self.active_formatting_elements_clear_until_marker();
             }
             Token::StartTagToken { name, .. } if name == "table" => {
-                if self.document.quirks_mode != QuirksMode::Quirks && self.is_in_scope("p", Scope::Button) {
+                if self.document.quirks_mode != QuirksMode::Quirks
+                    && self.is_in_scope("p", Scope::Button)
+                {
                     self.close_p_element();
                 }
 
@@ -2358,7 +2467,11 @@ impl<'a> Html5Parser<'a> {
 
                 acknowledge_closing_tag!(self, *is_self_closing);
             }
-            Token::StartTagToken { name, is_self_closing, .. } if name == "hr" => {
+            Token::StartTagToken {
+                name,
+                is_self_closing,
+                ..
+            } if name == "hr" => {
                 if self.is_in_scope("p", Scope::Button) {
                     self.close_p_element();
                 }
@@ -2865,30 +2978,34 @@ impl<'a> Html5Parser<'a> {
 
     // Remove the given node_id from the active formatting elements list
     fn active_formatting_elements_remove(&mut self, target_node_id: usize) {
-        self.active_formatting_elements.retain(|node_id| {
-            match node_id {
-                ActiveElement::NodeId(node_id) => {
-                    *node_id != target_node_id
-                },
+        self.active_formatting_elements
+            .retain(|node_id| match node_id {
+                ActiveElement::NodeId(node_id) => *node_id != target_node_id,
                 _ => true,
-            }
-        });
+            });
     }
 
     // Push a node onto the active formatting stack, make sure only max 3 of them can be added (between markers)
     fn active_formatting_elements_push(&mut self, node_id: usize) {
         let mut idx = self.active_formatting_elements.len();
         if idx == 0 {
-            self.active_formatting_elements.push(ActiveElement::NodeId(node_id));
+            self.active_formatting_elements
+                .push(ActiveElement::NodeId(node_id));
             return;
         }
 
         // Fetch the node we want to push, so we can compare
-        let element_node = self.document.get_node_by_id(node_id).expect("node id not found");
+        let element_node = self
+            .document
+            .get_node_by_id(node_id)
+            .expect("node id not found");
 
         let mut found = 0;
         loop {
-            let active_elem = *self.active_formatting_elements.get(idx - 1).expect("index out of bounds");
+            let active_elem = *self
+                .active_formatting_elements
+                .get(idx - 1)
+                .expect("index out of bounds");
             if let ActiveElement::Marker = active_elem {
                 // Don't continue after the last marker
                 break;
@@ -2896,7 +3013,10 @@ impl<'a> Html5Parser<'a> {
 
             // Fetch the node we want to compare with
             let match_node = match active_elem {
-                ActiveElement::NodeId(node_id) => self.document.get_node_by_id(node_id).expect("node id not found"),
+                ActiveElement::NodeId(node_id) => self
+                    .document
+                    .get_node_by_id(node_id)
+                    .expect("node id not found"),
                 ActiveElement::Marker => unreachable!(),
             };
             if match_node.matches_tag_and_attrs(element_node) {
@@ -2915,7 +3035,8 @@ impl<'a> Html5Parser<'a> {
             idx -= 1;
         }
 
-        self.active_formatting_elements.push(ActiveElement::NodeId(node_id));
+        self.active_formatting_elements
+            .push(ActiveElement::NodeId(node_id));
     }
 
     fn reconstruct_formatting(&mut self) {
@@ -2931,7 +3052,10 @@ impl<'a> Html5Parser<'a> {
             return;
         }
 
-        if self.open_elements.contains(&entry.node_id().expect("node id not found")) {
+        if self
+            .open_elements
+            .contains(&entry.node_id().expect("node id not found"))
+        {
             return;
         }
 
@@ -2943,7 +3067,10 @@ impl<'a> Html5Parser<'a> {
                 break;
             }
 
-            if self.open_elements.contains(&entry.node_id().expect("node id not found")) {
+            if self
+                .open_elements
+                .contains(&entry.node_id().expect("node id not found"))
+            {
                 break;
             }
 
@@ -2958,7 +3085,11 @@ impl<'a> Html5Parser<'a> {
             let entry = self.active_formatting_elements[entry_index];
             let node_id = entry.node_id().expect("node id not found");
 
-            let entry_node = self.document.get_node_by_id(node_id).expect("node not found").clone();
+            let entry_node = self
+                .document
+                .get_node_by_id(node_id)
+                .expect("node not found")
+                .clone();
             let new_node_id = self.clone_node(entry_node);
 
             self.active_formatting_elements[entry_index] = ActiveElement::NodeId(new_node_id);

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -2189,16 +2189,13 @@ impl<'a> Html5Parser<'a> {
                 any_other_end_tag = true;
             }
             Token::StartTagToken { name, .. } if name == "a" => {
-                match self.active_formatting_elements_has_until_marker("a") {
-                    Some(node_id) => {
-                        self.parse_error("a tag in active formatting elements");
-                        self.run_adoption_agency(&self.current_token.clone());
+                if let Some(node_id) = self.active_formatting_elements_has_until_marker("a") {
+                    self.parse_error("a tag in active formatting elements");
+                    self.run_adoption_agency(&self.current_token.clone());
 
-                        // Remove from lists if not done already by the adoption agency
-                        open_elements_remove!(self, node_id);
-                        self.active_formatting_elements_remove(node_id);
-                    }
-                    _ => {},
+                    // Remove from lists if not done already by the adoption agency
+                    open_elements_remove!(self, node_id);
+                    self.active_formatting_elements_remove(node_id);
                 }
 
                 self.reconstruct_formatting();
@@ -2891,7 +2888,7 @@ impl<'a> Html5Parser<'a> {
 
         let mut found = 0;
         loop {
-            let active_elem = self.active_formatting_elements.get(idx - 1).expect("index out of bounds").clone();
+            let active_elem = *self.active_formatting_elements.get(idx - 1).expect("index out of bounds");
             if let ActiveElement::Marker = active_elem {
                 // Don't continue after the last marker
                 break;
@@ -2927,7 +2924,7 @@ impl<'a> Html5Parser<'a> {
         }
 
         let mut entry_index: usize = self.active_formatting_elements.len() - 1;
-        let entry = self.active_formatting_elements[entry_index].clone();
+        let entry = self.active_formatting_elements[entry_index];
 
         // If it's a marker or in the stack of open elements, nothing to reconstruct.
         if let ActiveElement::Marker = entry {
@@ -2939,7 +2936,7 @@ impl<'a> Html5Parser<'a> {
         }
 
         loop {
-            let entry = self.active_formatting_elements[entry_index].clone();
+            let entry = self.active_formatting_elements[entry_index];
 
             // If it's a marker or in the stack of open elements, nothing to reconstruct.
             if let ActiveElement::Marker = entry {
@@ -2958,7 +2955,7 @@ impl<'a> Html5Parser<'a> {
         }
 
         loop {
-            let entry = self.active_formatting_elements[entry_index].clone();
+            let entry = self.active_formatting_elements[entry_index];
             let node_id = entry.node_id().expect("node id not found");
 
             let entry_node = self.document.get_node_by_id(node_id).expect("node not found").clone();

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -3107,7 +3107,7 @@ impl<'a> Html5Parser<'a> {
                 .get_node_by_id(node_id)
                 .expect("node not found")
                 .clone();
-            let new_node_id = self.clone_node(entry_node);
+            let new_node_id = self.clone_node_without_children(entry_node);
 
             self.active_formatting_elements[entry_index] = ActiveElement::NodeId(new_node_id);
 
@@ -3119,8 +3119,10 @@ impl<'a> Html5Parser<'a> {
         }
     }
 
-    fn clone_node(&mut self, org_node: Node) -> usize {
-        let new_node = org_node.clone();
+    fn clone_node_without_children(&mut self, org_node: Node) -> usize {
+        let mut new_node = org_node.clone();
+        new_node.children = Vec::new();
+        new_node.parent = None;
 
         let new_node_id = self.document.add_node(new_node, current_node!(self).id);
         if let NodeData::Element { .. } = org_node.data {

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -93,6 +93,10 @@ macro_rules! acknowledge_closing_tag {
 macro_rules! pop_until {
     ($self:expr, $name:expr) => {
         loop {
+            if $self.open_elements.is_empty() {
+                break;
+            }
+
             $self.open_elements.pop();
             if current_node!($self).name != $name {
                 break;
@@ -1665,7 +1669,7 @@ impl<'a> Html5Parser<'a> {
             let val = current_node!(self).name.clone();
 
             if except.is_some() && except.unwrap() == val {
-                return;
+                continue;
             }
 
             if thoroughly && !["tbody", "td", "tfoot", "th", "thead", "tr"].contains(&val.as_str())
@@ -3029,10 +3033,10 @@ impl<'a> Html5Parser<'a> {
                 }
             }
 
+            idx -= 1;
             if idx == 0 {
                 break;
             }
-            idx -= 1;
         }
 
         self.active_formatting_elements

--- a/src/html5_parser/parser/mod.rs
+++ b/src/html5_parser/parser/mod.rs
@@ -307,8 +307,6 @@ impl<'a> Html5Parser<'a> {
                 break;
             }
 
-            self.display_debug_info();
-
             // println!("Token: {}", self.current_token);
 
             match self.insertion_mode {
@@ -1606,6 +1604,9 @@ impl<'a> Html5Parser<'a> {
                     }
                 }
             }
+
+
+            self.display_debug_info();
         }
 
         (
@@ -3283,32 +3284,32 @@ impl<'a> Html5Parser<'a> {
 
     #[cfg(debug_assertions)]
     fn display_debug_info(&self) {
-        println!("** Frame **************************");
-        println!("current token  : {}", self.current_token);
-        println!("insertion mode : {:?}", self.insertion_mode);
-
-        println!("-- open elements  -----------");
+        println!("-----------------------------------------\n");
+        println!("current token   : {}", self.current_token);
+        println!("insertion mode  : {:?}", self.insertion_mode);
+        print!("Open elements   : [ ");
         for node_id in &self.open_elements {
             let node = self.document.get_node_by_id(*node_id).unwrap();
-            println!("({}) {}", node.id, node.name);
+            print!("{}, ", node.name);
         }
-        println!("-----------------------------");
+        println!("]");
 
-        println!("-- active formatting elems --");
+        print!("Active elements : [");
         for elem in &self.active_formatting_elements {
             match elem {
                 ActiveElement::NodeId(node_id) => {
                     let node = self.document.get_node_by_id(*node_id).unwrap();
-                    println!("({}) {}", node.id, node.name);
+                    print!("{}, ", node.name);
                 }
                 ActiveElement::Marker => {
-                    println!("marker");
+                    print!("marker");
                 }
             }
         }
-        println!("-----------------------------");
-        println!("-- TREE ---------------------");
+        println!("]");
+
+        println!("Output:");
         println!("{}", self.document);
-        println!("-----------------------------");
+
     }
 }


### PR DESCRIPTION
This PR tries to get the active element reconstruction running properly. It still fails horribly on the `<a><p>X<a>Y</a>Z</p></a>` test from test1.dat in the html5lib-tests repo. There are still some function implementations missing in the parser (mod.rs).