### PR TITLE
Add basic benchmarking using criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +114,54 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "convert_case"
@@ -115,6 +186,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +266,12 @@ dependencies = [
  "rustc_version",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -251,6 +397,7 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 name = "gosub-engine"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "derive_more",
  "lazy_static",
  "phf",
@@ -283,10 +430,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -392,6 +554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +606,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -481,12 +661,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -504,6 +693,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
@@ -548,6 +743,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "percent-encoding"
@@ -616,6 +817,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +900,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -782,6 +1031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +1047,12 @@ checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -824,6 +1088,9 @@ name = "serde"
 version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -965,6 +1232,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1500,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ keywords = ["html5", "parser"]
 name = "tokenizer"
 path = "tests/tokenizer.rs"
 
+[[bench]]
+name = "tokenizer"
+harness = false
+
 [dependencies]
 phf = { version = "0.11.2", features = ["macros"] }
 derive_more = "0.99"
@@ -24,4 +28,7 @@ regex = "1"
 lazy_static = "1.4"
 typed-arena = "2.0.2"
 reqwest = { version = "0.11.12", features = ["blocking"] }
+
+[dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
 test-case = "3.2.1"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ all: help
 
 test: test_unit test_clippy test_fmt ## Runs tests
 
+bench:
+	cargo bench
+
 build: ## Build	the project
 	source test-utils.sh ;\
 	section "Cargo build" ;\

--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gosub_engine::testing::tokenizer::{self, Test};
+
+fn tokenize(test: &Test) {
+    for mut builder in test.builders() {
+        let mut tokenizer = builder.build();
+
+        // If there is no output, still do an (initial) next token so the parser can generate
+        // errors.
+        if test.output.is_empty() {
+            tokenizer.next_token();
+        }
+
+        // There can be multiple tokens to match. Make sure we match all of them
+        for _ in test.output.iter() {
+            tokenizer.next_token();
+        }
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("tokenization", |b| {
+        b.iter(|| {
+            for root in tokenizer::fixtures() {
+                for test in &root.tests {
+                    tokenize(black_box(test))
+                }
+            }
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/tokenizer.rs
+++ b/benches/tokenizer.rs
@@ -19,15 +19,26 @@ fn tokenize(test: &Test) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("tokenization", |b| {
+    // Criterion can report inconsistent results from run to run in some cases.  We attempt to
+    // minimize that in this setup.
+    // https://stackoverflow.com/a/74136347/61048
+    let mut group = c.benchmark_group("tokenization");
+    group.significance_level(0.1).sample_size(500);
+
+    // Fetch the files outside of the closure to avoid issues with file io
+    let fixtures = tokenizer::fixtures().collect::<Vec<_>>();
+
+    group.bench_function("fixtures", |b| {
         b.iter(|| {
-            for root in tokenizer::fixtures() {
+            for root in &fixtures {
                 for test in &root.tests {
                     tokenize(black_box(test))
                 }
             }
         })
     });
+
+    group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -253,7 +253,7 @@ mod test {
         let node = Node::new_document();
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert!(node.children.is_empty());
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(node.data, NodeData::Document {});
@@ -266,7 +266,7 @@ mod test {
         let node = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert!(node.children.is_empty());
         assert_eq!(node.name, "div".to_string());
         assert_eq!(node.namespace, Some(HTML_NAMESPACE.into()));
         assert_eq!(
@@ -283,7 +283,7 @@ mod test {
         let node = Node::new_comment("test");
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert!(node.children.is_empty());
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(
@@ -299,7 +299,7 @@ mod test {
         let node = Node::new_text("test");
         assert_eq!(node.id, 0);
         assert_eq!(node.parent, None);
-        assert_eq!(node.children, vec![]);
+        assert!(node.children.is_empty());
         assert_eq!(node.name, "".to_string());
         assert_eq!(node.namespace, None);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
 #[allow(dead_code)]
 pub mod html5_parser;
-
 pub mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
 #[allow(dead_code)]
 pub mod html5_parser;
+
+pub mod testing;

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,0 +1,1 @@
+pub mod tokenizer;

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -1,0 +1,143 @@
+use regex::Regex;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{cell::RefCell, rc::Rc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use crate::html5_parser::{
+    error_logger::ErrorLogger,
+    input_stream::InputStream,
+    tokenizer::{
+        state::State as TokenState,
+        {Options, Tokenizer},
+    },
+};
+
+pub const FIXTURE_ROOT: &str = "./tests/data/html5lib-tests";
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Root {
+    pub tests: Vec<Test>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Error {
+    pub code: String,
+    pub line: i64,
+    pub col: i64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Test {
+    pub description: String,
+    pub input: String,
+    pub output: Vec<Vec<Value>>,
+    #[serde(default)]
+    pub errors: Vec<Error>,
+    #[serde(default)]
+    pub double_escaped: Option<bool>,
+    #[serde(default)]
+    pub initial_states: Vec<String>,
+    pub last_start_tag: Option<String>,
+}
+
+pub struct TokenizerBuilder {
+    input_stream: InputStream,
+    state: TokenState,
+    last_start_tag: Option<String>,
+}
+
+impl TokenizerBuilder {
+    pub fn build(&mut self) -> Tokenizer<'_> {
+        let error_logger = Rc::new(RefCell::new(ErrorLogger::new()));
+        Tokenizer::new(
+            &mut self.input_stream,
+            Some(Options {
+                initial_state: self.state,
+                last_start_tag: self.last_start_tag.to_owned().unwrap_or(String::from("")),
+            }),
+            error_logger.clone(),
+        )
+    }
+}
+
+impl Test {
+    pub fn builders(&self) -> Vec<TokenizerBuilder> {
+        let mut builders = vec![];
+
+        // If no initial state is given, assume Data state
+        let mut states = self.initial_states.clone();
+        if states.is_empty() {
+            states.push(String::from("Data state"));
+        }
+
+        for state in states.iter() {
+            let state = match state.as_str() {
+                "PLAINTEXT state" => TokenState::PlaintextState,
+                "RAWTEXT state" => TokenState::RawTextState,
+                "RCDATA state" => TokenState::RcDataState,
+                "Script data state" => TokenState::ScriptDataState,
+                "CDATA section state" => TokenState::CDataSectionState,
+                "Data state" => TokenState::DataState,
+                _ => panic!("unknown state found in test: {} ", state),
+            };
+
+            let mut is = InputStream::new();
+            let input = if self.double_escaped.unwrap_or(false) {
+                escape(self.input.as_str())
+            } else {
+                self.input.to_string()
+            };
+            is.read_from_str(input.as_str(), None);
+
+            let builder = TokenizerBuilder {
+                input_stream: is,
+                last_start_tag: self.last_start_tag.clone(),
+                state,
+            };
+
+            builders.push(builder);
+        }
+
+        builders
+    }
+}
+
+pub fn escape(input: &str) -> String {
+    let re = Regex::new(r"\\u([0-9a-fA-F]{4})").unwrap();
+    re.replace_all(input, |caps: &regex::Captures| {
+        let hex_val = u32::from_str_radix(&caps[1], 16).unwrap();
+
+        // This will also convert surrogates?
+        unsafe { char::from_u32_unchecked(hex_val).to_string() }
+    })
+    .into_owned()
+}
+
+pub fn from_filename(filename: &str) -> Result<Root, serde_json::Error> {
+    let path = PathBuf::from(FIXTURE_ROOT).join("tokenizer").join(filename);
+    from_path(&path)
+}
+
+pub fn from_path<P>(path: &P) -> Result<Root, serde_json::Error>
+where
+    P: AsRef<Path>,
+{
+    let contents = fs::read_to_string(path).unwrap();
+    // TODO: use thiserror to translate library errors
+    serde_json::from_str(&contents)
+}
+
+pub fn fixtures() -> impl Iterator<Item = Root> {
+    let root = PathBuf::from(FIXTURE_ROOT).join("tokenizer");
+    fs::read_dir(root).unwrap().flat_map(|entry| {
+        let path = format!("{}", entry.unwrap().path().display());
+        from_path(&path).ok()
+    })
+}

--- a/src/testing/tokenizer.rs
+++ b/src/testing/tokenizer.rs
@@ -120,12 +120,12 @@ pub fn escape(input: &str) -> String {
     .into_owned()
 }
 
-pub fn from_filename(filename: &str) -> Result<Root, serde_json::Error> {
+pub fn fixture_from_filename(filename: &str) -> Result<Root, serde_json::Error> {
     let path = PathBuf::from(FIXTURE_ROOT).join("tokenizer").join(filename);
-    from_path(&path)
+    fixture_from_path(&path)
 }
 
-pub fn from_path<P>(path: &P) -> Result<Root, serde_json::Error>
+pub fn fixture_from_path<P>(path: &P) -> Result<Root, serde_json::Error>
 where
     P: AsRef<Path>,
 {
@@ -138,6 +138,6 @@ pub fn fixtures() -> impl Iterator<Item = Root> {
     let root = PathBuf::from(FIXTURE_ROOT).join("tokenizer");
     fs::read_dir(root).unwrap().flat_map(|entry| {
         let path = format!("{}", entry.unwrap().path().display());
-        from_path(&path).ok()
+        fixture_from_path(&path).ok()
     })
 }

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -1,83 +1,14 @@
-use gosub_engine::html5_parser::error_logger::ErrorLogger;
-use regex::Regex;
-use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::PathBuf;
-use std::rc::Rc;
 use test_case::test_case;
 
-use gosub_engine::html5_parser::input_stream::InputStream;
-use gosub_engine::html5_parser::tokenizer::state::State as TokenState;
 use gosub_engine::html5_parser::tokenizer::token::{Attribute, Token, TokenTrait, TokenType};
-use gosub_engine::html5_parser::tokenizer::{Options, Tokenizer};
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Root {
-    pub tests: Vec<Test>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Test {
-    pub description: String,
-    pub input: String,
-    pub output: Vec<Vec<Value>>,
-    #[serde(default)]
-    pub errors: Vec<Error>,
-    #[serde(default)]
-    pub double_escaped: Option<bool>,
-    #[serde(default)]
-    pub initial_states: Vec<String>,
-    pub last_start_tag: Option<String>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Error {
-    pub code: String,
-    pub line: i64,
-    pub col: i64,
-}
+use gosub_engine::html5_parser::tokenizer::Tokenizer;
+use gosub_engine::testing::tokenizer::{self, escape, Error, Test};
 
 fn assert_tokenization(test: &Test) {
-    // If no initial state is given, assume Data state
-    let mut states = test.initial_states.clone();
-    if states.is_empty() {
-        states.push(String::from("Data state"));
-    }
-
-    for state in states.iter() {
-        let state = match state.as_str() {
-            "PLAINTEXT state" => TokenState::PlaintextState,
-            "RAWTEXT state" => TokenState::RawTextState,
-            "RCDATA state" => TokenState::RcDataState,
-            "Script data state" => TokenState::ScriptDataState,
-            "CDATA section state" => TokenState::CDataSectionState,
-            "Data state" => TokenState::DataState,
-            _ => panic!("unknown state found in test: {} ", state),
-        };
-
-        let mut is = InputStream::new();
-        let input = if test.double_escaped.unwrap_or(false) {
-            escape(test.input.as_str())
-        } else {
-            test.input.to_string()
-        };
-        is.read_from_str(input.as_str(), None);
-
-        let error_logger = Rc::new(RefCell::new(ErrorLogger::new()));
-        let mut tokenizer = Tokenizer::new(
-            &mut is,
-            Some(Options {
-                initial_state: state,
-                last_start_tag: test.last_start_tag.clone().unwrap_or(String::from("")),
-            }),
-            error_logger.clone(),
-        );
+    for mut builder in test.builders() {
+        let mut tokenizer = builder.build();
 
         // If there is no output, still do an (initial) next token so the parser can generate
         // errors.
@@ -91,7 +22,7 @@ fn assert_tokenization(test: &Test) {
             assert_token(t, expected_token, test.double_escaped.unwrap_or(false));
         }
 
-        let borrowed_error_logger = error_logger.borrow();
+        let borrowed_error_logger = tokenizer.error_logger.borrow();
         assert_eq!(borrowed_error_logger.get_errors().len(), test.errors.len());
 
         // Check error messages
@@ -266,13 +197,7 @@ fn assert_doctype(
     let expected_sys = expected[3].as_str();
     let expected_quirk = expected[4].as_bool();
 
-    match (expected_name, &name) {
-        (Some(_), Some(_)) | (None, Some(_)) | (Some(_), None) => {
-            assert_eq!(expected_name, name.as_deref(), "incorrect doctype");
-        }
-
-        (None, None) => {}
-    }
+    assert_eq!(expected_name, name.as_deref(), "incorrect doctype");
 
     if let Some(expected_quirk) = expected_quirk {
         assert_ne!(
@@ -299,17 +224,6 @@ fn assert_doctype(
     );
 }
 
-fn escape(input: &str) -> String {
-    let re = Regex::new(r"\\u([0-9a-fA-F]{4})").unwrap();
-    re.replace_all(input, |caps: &regex::Captures| {
-        let hex_val = u32::from_str_radix(&caps[1], 16).unwrap();
-
-        // This will also convert surrogates?
-        unsafe { char::from_u32_unchecked(hex_val).to_string() }
-    })
-    .into_owned()
-}
-
 #[test_case("contentModelFlags.test")]
 #[test_case("domjs.test")]
 #[test_case("entities.test")]
@@ -325,12 +239,8 @@ fn escape(input: &str) -> String {
 #[test_case("unicodeChars.test")]
 // #[test_case("xmlViolation.test")]
 fn tokenization(filename: &str) {
-    const ROOT: &str = "./tests/data/html5lib-tests/tokenizer";
-    let path = PathBuf::from(ROOT).join(filename);
-    let contents = fs::read_to_string(&path).unwrap();
-    let container: Root = serde_json::from_str(&contents).unwrap();
-
-    for test in container.tests {
+    let root = tokenizer::from_filename(&filename).unwrap();
+    for test in root.tests {
         assert_tokenization(&test)
     }
 }

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -239,7 +239,7 @@ fn assert_doctype(
 #[test_case("unicodeChars.test")]
 // #[test_case("xmlViolation.test")]
 fn tokenization(filename: &str) {
-    let root = tokenizer::from_filename(&filename).unwrap();
+    let root = tokenizer::fixture_from_filename(&filename).unwrap();
     for test in root.tests {
         assert_tokenization(&test)
     }


### PR DESCRIPTION
This PR adds a simple benchmarking harness as an example of the kind of thing that can be done using a library called [criterion](https://github.com/bheisler/criterion.rs).

The `criterion` library is a well-known Rust library that is often used for this kind of thing.  The benchmark in this PR is just an example; hopefully it will be straightforward to extend to more substantial cases.  Its comparisons from run to run are a little noisy, but I suspect this can be dialed in.  Examples of people using `criterion` [here](https://youtu.be/3oL1xokuHBE?si=QXfqvjiszlfJ2ds1&t=10176) and [here](https://fasterthanli.me/series/advent-of-code-2022/part-17#performance-comparison-with-criterion).

To run the suite, do:

```sh
$ make bench
$ cargo bench
```

I'll leave this PR in draft since I didn't discuss it first.

![2023-09-29_17-59](https://github.com/jaytaph/gosub-browser/assets/760949/971a510b-65a7-42b8-87b7-bbc4d50bd5a5)

![2023-09-29_17-53](https://github.com/jaytaph/gosub-browser/assets/760949/b44ef87c-e5c8-492f-8b55-dc3ada40535e)

![2023-09-29_17-56](https://github.com/jaytaph/gosub-browser/assets/760949/ebe5fdcf-5d23-4c02-bc68-0dafa662f9f2)
