### PR TITLE
test(token): add unit test for comment that contains html

### DIFF
--- a/src/html5_parser/tokenizer/token.rs
+++ b/src/html5_parser/tokenizer/token.rs
@@ -206,6 +206,14 @@ mod tests {
     }
 
     #[test]
+    fn test_token_display_comment_with_html() {
+        let token = Token::CommentToken {
+            value: "<p>Hello world</p>".to_string(),
+        };
+        assert_eq!(format!("{}", token), "<!-- <p>Hello world</p> -->");
+    }
+
+    #[test]
     fn test_token_display_text() {
         let token = Token::TextToken {
             value: "Hello World".to_string(),


### PR DESCRIPTION
Hey there, I stumbled across this project and right now I am starting to get to know the internals. I am also a Rust beginner so this is a great way for me to learn and I would love to start contribute as early as possible. When I was analyzing `token.rs` file, I noticed that it would be worth to also test a case when the comment contains HTML tag. I think this is also a possibility and it would be good that it is prevented on the unit test level.