### PR TITLE
ci: deploy docs to github pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -119,3 +119,18 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - name: Run fmt
         run: cargo fmt -- --check
+
+  docs:
+    if: github.event.pull_request.merged && github.event.pull_request.base.ref == 'main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build docs
+        run: cargo doc --no-deps
+      - name: Prepare docs
+        run: echo "<meta http-equiv=\"refresh\" content=\"0; url=gosub_engine\">" > target/doc/index.html
+      - name: Deploy to github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc


### PR DESCRIPTION
This patch adds a new job to the GitHub workflow to generate docs and deploy them to GH pages.

The job is only triggered when the PR is merged into the "main" branch. It needs access to the "GITHUB_TOKEN" of the repo owner. It will push the "target/doc" directory to a branch called "gh-pages" in the root directory.

The repo owner will need to update the repo settings to make GitHub deploy to this directory.