### PR TITLE
Prefer &str to String for function arguments

### DIFF
--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -704,14 +704,14 @@ mod tests {
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
         assert!(node.clear_attributes().is_ok());
-        assert_eq!(node.has_attributes(), false);
+        assert!(!node.has_attributes());
     }
 
     #[test]
     fn has_attributes_non_element() {
         // if node is a non-element, will always return false
         let node = Node::new_document();
-        assert_eq!(node.has_attributes(), false);
+        assert!(!node.has_attributes());
     }
 
     #[test]
@@ -722,6 +722,6 @@ mod tests {
         assert_eq!(node.has_attributes(), false);
 
         assert!(node.insert_attribute("key", "value").is_ok());
-        assert_eq!(node.has_attributes(), true);
+        assert!(node.has_attributes());
     }
 }

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -394,7 +394,7 @@ pub static SPECIAL_MATHML_ELEMENTS: [&str; 6] = ["mi", "mo", "mn", "ms", "mtext"
 pub static SPECIAL_SVG_ELEMENTS: [&str; 3] = ["foreignObject", "desc", "title"];
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/html5_parser/node.rs
+++ b/src/html5_parser/node.rs
@@ -190,13 +190,13 @@ impl Node {
     }
 
     /// Check if an attribute exists
-    pub fn contains_attribute(&self, name: String) -> Result<bool, String> {
+    pub fn contains_attribute(&self, name: &str) -> Result<bool, String> {
         if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
+            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
         }
 
         let contains: bool = match &self.data {
-            NodeData::Element { attributes, .. } => attributes.contains_key(&name),
+            NodeData::Element { attributes, .. } => attributes.contains_key(name),
             _ => false,
         };
 
@@ -204,26 +204,26 @@ impl Node {
     }
 
     /// Add or update a an attribute
-    pub fn insert_attribute(&mut self, name: String, value: String) -> Result<(), String> {
+    pub fn insert_attribute(&mut self, name: &str, value: &str) -> Result<(), String> {
         if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
+            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
         }
 
         if let NodeData::Element { attributes, .. } = &mut self.data {
-            attributes.insert(name, value);
+            attributes.insert(name.to_owned(), value.to_owned());
         }
 
         Ok(())
     }
 
     /// Remove an attribute. If attribute doesn't exist, nothing happens.
-    pub fn remove_attribute(&mut self, name: String) -> Result<(), String> {
+    pub fn remove_attribute(&mut self, name: &str) -> Result<(), String> {
         if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
+            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
         }
 
         if let NodeData::Element { attributes, .. } = &mut self.data {
-            attributes.remove(&name);
+            attributes.remove(name);
         }
 
         Ok(())
@@ -231,14 +231,14 @@ impl Node {
 
     /// Get a constant reference to the attribute value
     /// (or None if attribute doesn't exist)
-    pub fn get_attribute(&self, name: String) -> Result<Option<&String>, String> {
+    pub fn get_attribute(&self, name: &str) -> Result<Option<&String>, String> {
         if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
+            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
         }
 
         let mut value: Option<&String> = None;
         if let NodeData::Element { attributes, .. } = &self.data {
-            value = attributes.get(&name);
+            value = attributes.get(name);
         }
 
         Ok(value)
@@ -246,14 +246,14 @@ impl Node {
 
     /// Get a mutable reference to the attribute value
     /// (or None if the attribute doesn't exist)
-    pub fn get_mut_attribute(&mut self, name: String) -> Result<Option<&mut String>, String> {
+    pub fn get_mut_attribute(&mut self, name: &str) -> Result<Option<&mut String>, String> {
         if self.type_of() != NodeType::Element {
-            return Err(String::from(ATTRIBUTE_NODETYPE_ERR_MSG));
+            return Err(ATTRIBUTE_NODETYPE_ERR_MSG.into());
         }
 
         let mut value: Option<&mut String> = None;
         if let NodeData::Element { attributes, .. } = &mut self.data {
-            value = attributes.get_mut(&name);
+            value = attributes.get_mut(name);
         }
 
         Ok(value)
@@ -398,7 +398,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_new_document() {
+    fn new_document() {
         let node = Node::new_document();
         assert_eq!(node.id, NodeId::default());
         assert_eq!(node.parent, None);
@@ -409,7 +409,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_element() {
+    fn new_element() {
         let mut attributes = HashMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
@@ -428,7 +428,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_comment() {
+    fn new_comment() {
         let node = Node::new_comment("test");
         assert_eq!(node.id, NodeId::default());
         assert_eq!(node.parent, None);
@@ -444,7 +444,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_text() {
+    fn new_text() {
         let node = Node::new_text("test");
         assert_eq!(node.id, NodeId::default());
         assert_eq!(node.parent, None);
@@ -460,7 +460,7 @@ mod test {
     }
 
     #[test]
-    fn test_is_special() {
+    fn is_special() {
         let mut attributes = HashMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element("div", attributes, HTML_NAMESPACE);
@@ -468,7 +468,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of() {
+    fn type_of() {
         let node = Node::new_document();
         assert_eq!(node.type_of(), NodeType::Document);
         let node = Node::new_text("test");
@@ -482,7 +482,7 @@ mod test {
     }
 
     #[test]
-    fn test_special_html_elements() {
+    fn special_html_elements() {
         for element in SPECIAL_HTML_ELEMENTS.iter() {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
@@ -492,7 +492,7 @@ mod test {
     }
 
     #[test]
-    fn test_special_mathml_elements() {
+    fn special_mathml_elements() {
         for element in SPECIAL_MATHML_ELEMENTS.iter() {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
@@ -502,7 +502,7 @@ mod test {
     }
 
     #[test]
-    fn test_special_svg_elements() {
+    fn special_svg_elements() {
         for element in SPECIAL_SVG_ELEMENTS.iter() {
             let mut attributes = HashMap::new();
             attributes.insert("id".to_string(), "test".to_string());
@@ -512,7 +512,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node() {
+    fn type_of_node() {
         let node = Node::new_document();
         assert_eq!(node.type_of(), NodeType::Document);
         let node = Node::new_text("test");
@@ -526,7 +526,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node_data() {
+    fn type_of_node_data() {
         let node = Node::new_document();
         assert_eq!(node.data, NodeData::Document {});
         let node = Node::new_text("test");
@@ -556,7 +556,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node_data_element() {
+    fn type_of_node_data_element() {
         let mut attributes = HashMap::new();
         attributes.insert("id".to_string(), "test".to_string());
         let node = Node::new_element("div", attributes.clone(), HTML_NAMESPACE);
@@ -570,7 +570,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node_data_text() {
+    fn type_of_node_data_text() {
         let node = Node::new_text("test");
         assert_eq!(
             node.data,
@@ -581,7 +581,7 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node_data_comment() {
+    fn type_of_node_data_comment() {
         let node = Node::new_comment("test");
         assert_eq!(
             node.data,
@@ -592,167 +592,136 @@ mod test {
     }
 
     #[test]
-    fn test_type_of_node_data_document() {
+    fn type_of_node_data_document() {
         let node = Node::new_document();
         assert_eq!(node.data, NodeData::Document {});
     }
 
     #[test]
-    fn test_contains_attribute_non_element() {
+    fn contains_attribute_non_element() {
         let node = Node::new_document();
-        let result = node.contains_attribute("x".to_string());
+        let result = node.contains_attribute("x");
         assert!(result.is_err())
     }
 
     #[test]
-    fn test_contains_attribute() {
+    fn contains_attribute() {
         let mut attr = HashMap::new();
         attr.insert("x".to_string(), "value".to_string());
 
         let node = Node::new_element("node", attr.clone(), HTML_NAMESPACE);
 
-        match node.contains_attribute("x".to_string()) {
-            Err(_) => assert!(false),
-            Ok(result) => {
-                assert_eq!(result, true);
-            }
-        }
-
-        match node.contains_attribute("z".to_string()) {
-            Err(_) => assert!(false),
-            Ok(result) => {
-                assert_eq!(result, false);
-            }
-        }
+        assert!(node.contains_attribute("x").unwrap());
+        assert!(!node.contains_attribute("z").unwrap());
     }
 
     #[test]
-    fn test_insert_attrubte_non_element() {
+    fn insert_attrubte_non_element() {
         let mut node = Node::new_document();
-        let result = node.insert_attribute("name".to_string(), "value".to_string());
+        let result = node.insert_attribute("name", "value");
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_insert_attribute() {
+    fn insert_attribute() {
         let attr = HashMap::new();
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
-        if let Ok(_) = node.insert_attribute("key".to_string(), "value".to_string()) {
-            if let Ok(value) = node.get_attribute("key".to_string()) {
-                match value {
-                    None => assert!(false),
-                    Some(val) => assert_eq!(*val, "value".to_string()),
-                }
-            }
-        }
+
+        assert!(node.insert_attribute("key", "value").is_ok());
+        let value = node.get_attribute("key").unwrap().unwrap();
+        assert_eq!(value, "value");
     }
 
     #[test]
-    fn test_remove_attribute_non_element() {
+    fn remove_attribute_non_element() {
         let mut node = Node::new_document();
-        let result = node.remove_attribute("name".to_string());
+        let result = node.remove_attribute("name");
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_remove_attribute() {
+    fn remove_attribute() {
         let mut attr = HashMap::new();
         attr.insert("key".to_string(), "value".to_string());
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
 
-        if let Ok(_) = node.remove_attribute("key".to_string()) {
-            if let Ok(result) = node.contains_attribute("key".to_string()) {
-                assert_eq!(result, false);
-            }
-        }
+        assert!(node.remove_attribute("key").is_ok());
+        let result = node.contains_attribute("key").unwrap();
+        assert!(!result);
     }
 
     #[test]
-    fn test_get_attribute_non_element() {
+    fn get_attribute_non_element() {
         let node = Node::new_document();
-        let result = node.get_attribute("name".to_string());
+        let result = node.get_attribute("name");
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_get_attribute() {
+    fn get_attribute() {
         let mut attr = HashMap::new();
         attr.insert("key".to_string(), "value".to_string());
 
         let node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
 
-        if let Ok(value) = node.get_attribute("key".to_string()) {
-            match value {
-                None => assert!(false),
-                Some(value_str) => assert_eq!(*value_str, "value".to_string()),
-            }
-        }
+        let value = node.get_attribute("key").unwrap().unwrap();
+        assert_eq!(value, "value");
     }
 
     #[test]
-    fn test_get_mut_attribute_non_element() {
+    fn get_mut_attribute_non_element() {
         let mut node = Node::new_document();
-        let result = node.get_mut_attribute("key".to_string());
+        let result = node.get_mut_attribute("key");
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_get_mut_attribute() {
+    fn get_mut_attribute() {
         let mut attr = HashMap::new();
         attr.insert("key".to_string(), "value".to_string());
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
 
-        if let Ok(value) = node.get_mut_attribute("key".to_string()) {
-            match value {
-                None => assert!(false),
-                Some(value_str) => (*value_str).push_str(" appended"),
-            }
+        let value = node.get_mut_attribute("key").unwrap().unwrap();
+        value.push_str(" appended");
 
-            if let Ok(value2) = node.get_attribute("key".to_string()) {
-                match value2 {
-                    None => assert!(false),
-                    Some(value_str) => assert_eq!(*value_str, "value appended"),
-                }
-            }
-        }
+        let value = node.get_attribute("key").unwrap().unwrap();
+        assert_eq!(value, "value appended");
     }
 
     #[test]
-    fn test_clear_attributes_non_element() {
+    fn clear_attributes_non_element() {
         let mut node = Node::new_document();
         let result = node.clear_attributes();
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_clear_attributes() {
+    fn clear_attributes() {
         let mut attr = HashMap::new();
         attr.insert("key".to_string(), "value".to_string());
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
-        if let Ok(_) = node.clear_attributes() {
-            assert_eq!(node.has_attributes(), false);
-        }
+        assert!(node.clear_attributes().is_ok());
+        assert_eq!(node.has_attributes(), false);
     }
 
     #[test]
-    fn test_has_attributes_non_element() {
+    fn has_attributes_non_element() {
         // if node is a non-element, will always return false
         let node = Node::new_document();
         assert_eq!(node.has_attributes(), false);
     }
 
     #[test]
-    fn test_has_attributes() {
+    fn has_attributes() {
         let attr = HashMap::new();
 
         let mut node = Node::new_element("name", attr.clone(), HTML_NAMESPACE);
         assert_eq!(node.has_attributes(), false);
 
-        if let Ok(_) = node.insert_attribute("key".to_string(), "value".to_string()) {
-            assert_eq!(node.has_attributes(), true);
-        }
+        assert!(node.insert_attribute("key", "value").is_ok());
+        assert_eq!(node.has_attributes(), true);
     }
 }

--- a/src/html5_parser/tokenizer/character_reference.rs
+++ b/src/html5_parser/tokenizer/character_reference.rs
@@ -23,12 +23,10 @@ pub enum CcrState {
 
 macro_rules! consume_temp_buffer {
     ($self:expr, $as_attribute:expr) => {
-        for c in $self.temporary_buffer.clone() {
-            if $as_attribute {
-                $self.current_attr_value.push(c);
-            } else {
-                $self.consume(c);
-            }
+        if $as_attribute {
+            $self.current_attr_value.push_str(&$self.temporary_buffer);
+        } else {
+            $self.consumed.push_str(&$self.temporary_buffer);
         }
         $self.temporary_buffer.clear();
     };
@@ -50,7 +48,8 @@ impl<'a> Tokenizer<'a> {
         loop {
             match ccr_state {
                 CcrState::CharacterReference => {
-                    self.temporary_buffer = vec!['&'];
+                    self.temporary_buffer.clear();
+                    self.temporary_buffer.push('&');
 
                     let c = read_char!(self);
                     match c {
@@ -299,8 +298,9 @@ impl<'a> Tokenizer<'a> {
                         }
                     }
 
-                    self.temporary_buffer =
-                        vec![char::from_u32(char_ref_code).unwrap_or(CHAR_REPLACEMENT)];
+                    self.temporary_buffer.clear();
+                    let c = char::from_u32(char_ref_code).unwrap_or(CHAR_REPLACEMENT);
+                    self.temporary_buffer.push(c);
                     consume_temp_buffer!(self, as_attribute);
 
                     return;

--- a/src/html5_parser/tokenizer/mod.rs
+++ b/src/html5_parser/tokenizer/mod.rs
@@ -529,7 +529,7 @@ impl<'a> Tokenizer<'a> {
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
                                 let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(s);
+                                self.set_name_in_current_token(&s);
 
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
@@ -633,7 +633,7 @@ impl<'a> Tokenizer<'a> {
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
                                 let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(s);
+                                self.set_name_in_current_token(&s);
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
                                 self.state = State::DataState;
@@ -738,7 +738,7 @@ impl<'a> Tokenizer<'a> {
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
                                 let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(s);
+                                self.set_name_in_current_token(&s);
 
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
@@ -942,7 +942,7 @@ impl<'a> Tokenizer<'a> {
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
                                 let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(s);
+                                self.set_name_in_current_token(&s);
 
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
@@ -2304,22 +2304,22 @@ impl<'a> Tokenizer<'a> {
     }
 
     // Adds a new attribute to the current token
-    fn set_add_attribute_to_current_token(&mut self, name: String, value: String) {
+    fn set_add_attribute_to_current_token(&mut self, name: &str, value: &str) {
         if let Token::StartTagToken { attributes, .. } = &mut self.current_token.as_mut().unwrap() {
-            attributes.insert(name.clone(), value.clone());
+            attributes.insert(name.into(), value.into());
         }
 
         self.current_attr_name.clear()
     }
 
     // Sets the given name into the current token
-    fn set_name_in_current_token(&mut self, new_name: String) {
+    fn set_name_in_current_token(&mut self, new_name: &str) {
         match &mut self.current_token.as_mut().unwrap() {
             Token::StartTagToken { name, .. } => {
-                *name = new_name.clone();
+                *name = new_name.into();
             }
             Token::EndTagToken { name, .. } => {
-                *name = new_name.clone();
+                *name = new_name.into();
             }
             _ => panic!("trying to set the name of a non start/end tag token"),
         }

--- a/src/html5_parser/tokenizer/mod.rs
+++ b/src/html5_parser/tokenizer/mod.rs
@@ -27,12 +27,12 @@ pub const CHAR_REPLACEMENT: char = '\u{FFFD}';
 pub struct Tokenizer<'a> {
     pub stream: &'a mut InputStream, // HTML character input stream
     pub state: State,                // Current state of the tokenizer
-    pub consumed: Vec<char>,         // Current consumed characters for current token
+    pub consumed: String,            // Current consumed characters for current token
     pub current_attr_name: String, // Current attribute name that we need to store temporary in case we are parsing attributes
     pub current_attr_value: String, // Current attribute value that we need to store temporary in case we are parsing attributes
     pub current_attrs: HashMap<String, String>, // Current attributes
     pub current_token: Option<Token>, // Token that is currently in the making (if any)
-    pub temporary_buffer: Vec<char>, // Temporary buffer
+    pub temporary_buffer: String,   // Temporary buffer
     pub token_queue: Vec<Token>, // Queue of emitted tokens. Needed because we can generate multiple tokens during iteration
     pub last_start_token: String, // The last emitted start token (or empty if none)
     pub error_logger: Rc<RefCell<ErrorLogger>>, // Parse errors
@@ -183,9 +183,8 @@ macro_rules! emit_token {
 
         // If there is any consumed data, emit this first as a text token
         if $self.has_consumed_data() {
-            $self.token_queue.push(Token::TextToken {
-                value: $self.get_consumed_str(),
-            });
+            let value = $self.get_consumed_str().to_string();
+            $self.token_queue.push(Token::TextToken { value });
             $self.clear_consume_buffer();
         }
 
@@ -206,13 +205,13 @@ impl<'a> Tokenizer<'a> {
             last_start_token: opts
                 .as_ref()
                 .map_or(String::new(), |o| o.last_start_tag.clone()),
-            consumed: vec![],
+            consumed: String::new(),
             current_token: None,
             token_queue: vec![],
             current_attr_name: String::new(),
             current_attr_value: String::new(),
             current_attrs: HashMap::new(),
-            temporary_buffer: vec![],
+            temporary_buffer: String::new(),
             error_logger,
         };
     }
@@ -463,7 +462,7 @@ impl<'a> Tokenizer<'a> {
                     let c = read_char!(self);
                     match c {
                         Element::Utf8('/') => {
-                            self.temporary_buffer = vec![];
+                            self.temporary_buffer.clear();
                             self.state = State::RcDataEndTagOpenState;
                         }
                         _ => {
@@ -528,8 +527,7 @@ impl<'a> Tokenizer<'a> {
                         }
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
-                                let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(&s);
+                                self.set_name_in_current_token(self.temporary_buffer.clone());
 
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
@@ -550,22 +548,14 @@ impl<'a> Tokenizer<'a> {
                     }
 
                     if consume_anything_else {
-                        self.consume('<');
-                        self.consume('/');
-                        for c in self.temporary_buffer.clone() {
-                            self.consume(c);
-                        }
-                        self.temporary_buffer.clear();
-
-                        self.stream.unread();
-                        self.state = State::RcDataState;
+                        self.transition_to(State::RcDataState);
                     }
                 }
                 State::RawTextLessThanSignState => {
                     let c = read_char!(self);
                     match c {
                         Element::Utf8('/') => {
-                            self.temporary_buffer = vec![];
+                            self.temporary_buffer.clear();
                             self.state = State::RawTextEndTagOpenState;
                         }
                         _ => {
@@ -632,8 +622,7 @@ impl<'a> Tokenizer<'a> {
                         }
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
-                                let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(&s);
+                                self.set_name_in_current_token(self.temporary_buffer.clone());
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
                                 self.state = State::DataState;
@@ -655,22 +644,14 @@ impl<'a> Tokenizer<'a> {
                     }
 
                     if consume_anything_else {
-                        self.consume('<');
-                        self.consume('/');
-                        for c in self.temporary_buffer.clone() {
-                            self.consume(c);
-                        }
-                        self.temporary_buffer.clear();
-
-                        self.stream.unread();
-                        self.state = State::RawTextState;
+                        self.transition_to(State::RawTextState);
                     }
                 }
                 State::ScriptDataLessThenSignState => {
                     let c = read_char!(self);
                     match c {
                         Element::Utf8('/') => {
-                            self.temporary_buffer = vec![];
+                            self.temporary_buffer.clear();
                             self.state = State::ScriptDataEndTagOpenState;
                         }
                         Element::Utf8('!') => {
@@ -737,8 +718,7 @@ impl<'a> Tokenizer<'a> {
                         }
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
-                                let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(&s);
+                                self.set_name_in_current_token(self.temporary_buffer.clone());
 
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
@@ -759,15 +739,7 @@ impl<'a> Tokenizer<'a> {
                     }
 
                     if consume_anything_else {
-                        self.consume('<');
-                        self.consume('/');
-                        for c in self.temporary_buffer.clone() {
-                            self.consume(c);
-                        }
-                        self.temporary_buffer.clear();
-
-                        self.stream.unread();
-                        self.state = State::ScriptDataState;
+                        self.transition_to(State::ScriptDataState);
                     }
                 }
                 State::ScriptDataEscapeStartState => {
@@ -876,12 +848,12 @@ impl<'a> Tokenizer<'a> {
                     let c = read_char!(self);
                     match c {
                         Element::Utf8('/') => {
-                            self.temporary_buffer = vec![];
+                            self.temporary_buffer.clear();
                             self.state = State::ScriptDataEscapedEndTagOpenState;
                         }
                         _ => {
                             if c.is_utf8() && c.utf8().is_ascii_alphabetic() {
-                                self.temporary_buffer = vec![];
+                                self.temporary_buffer.clear();
                                 self.consume('<');
                                 self.stream.unread();
                                 self.state = State::ScriptDataDoubleEscapeStartState;
@@ -941,9 +913,7 @@ impl<'a> Tokenizer<'a> {
                         }
                         Element::Utf8('>') => {
                             if self.is_appropriate_end_token(&self.temporary_buffer) {
-                                let s: String = self.temporary_buffer.iter().collect::<String>();
-                                self.set_name_in_current_token(&s);
-
+                                self.set_name_in_current_token(self.temporary_buffer.clone());
                                 self.last_start_token = String::new();
                                 emit_current_token!(self);
                                 self.state = State::DataState;
@@ -963,15 +933,7 @@ impl<'a> Tokenizer<'a> {
                     }
 
                     if consume_anything_else {
-                        self.consume('<');
-                        self.consume('/');
-                        for c in self.temporary_buffer.clone() {
-                            self.consume(c);
-                        }
-                        self.temporary_buffer.clear();
-
-                        self.stream.unread();
-                        self.state = State::ScriptDataEscapedState;
+                        self.transition_to(State::ScriptDataEscapedState);
                     }
                 }
                 State::ScriptDataDoubleEscapeStartState => {
@@ -983,12 +945,7 @@ impl<'a> Tokenizer<'a> {
                         | Element::Utf8(CHAR_SPACE)
                         | Element::Utf8('/')
                         | Element::Utf8('>') => {
-                            if self
-                                .temporary_buffer
-                                .iter()
-                                .collect::<String>()
-                                .eq("script")
-                            {
+                            if self.temporary_buffer == "script" {
                                 self.state = State::ScriptDataDoubleEscapedState;
                             } else {
                                 self.state = State::ScriptDataEscapedState;
@@ -1088,7 +1045,7 @@ impl<'a> Tokenizer<'a> {
                     let c = read_char!(self);
                     match c {
                         Element::Utf8('/') => {
-                            self.temporary_buffer = vec![];
+                            self.temporary_buffer.clear();
                             self.consume('/');
                             self.state = State::ScriptDataDoubleEscapeEndState;
                         }
@@ -1107,12 +1064,7 @@ impl<'a> Tokenizer<'a> {
                         | Element::Utf8(CHAR_SPACE)
                         | Element::Utf8('/')
                         | Element::Utf8('>') => {
-                            if self
-                                .temporary_buffer
-                                .iter()
-                                .collect::<String>()
-                                .eq("script")
-                            {
+                            if self.temporary_buffer == "script" {
                                 self.state = State::ScriptDataEscapedState;
                             } else {
                                 self.state = State::ScriptDataDoubleEscapedState;
@@ -2241,23 +2193,29 @@ impl<'a> Tokenizer<'a> {
         self.consumed.push(c)
     }
 
-    // Consumes the given string
-    pub(crate) fn consume_string(&mut self, s: &str) {
-        // Add c to the current token data
-        for c in s.chars() {
-            self.consumed.push(c)
-        }
+    fn transition_to(&mut self, state: State) {
+        self.consumed.push_str("</");
+        self.consumed.push_str(&self.temporary_buffer);
+        self.temporary_buffer.clear();
+        self.stream.unread();
+        self.state = state;
     }
 
-    // Return true when the given end_token matches the stored start token (ie: 'table' matches when last_start_token = 'table')
-    fn is_appropriate_end_token(&self, end_token: &[char]) -> bool {
-        let s: String = end_token.iter().collect();
-        self.last_start_token == s
+    // Consumes the given string
+    pub(crate) fn consume_str(&mut self, s: &str) {
+        // Add s to the current token data
+        self.consumed.push_str(s);
+    }
+
+    // Return true when the given end_token matches the stored start token (ie: 'table' matches when
+    // last_start_token = 'table')
+    fn is_appropriate_end_token(&self, end_token: &str) -> bool {
+        self.last_start_token == end_token
     }
 
     // Return the consumed string as a String
-    pub fn get_consumed_str(&self) -> String {
-        return self.consumed.iter().collect();
+    pub fn get_consumed_str(&self) -> &str {
+        &self.consumed
     }
 
     // Returns true if there is anything in the consume buffer
@@ -2313,13 +2271,13 @@ impl<'a> Tokenizer<'a> {
     }
 
     // Sets the given name into the current token
-    fn set_name_in_current_token(&mut self, new_name: &str) {
+    fn set_name_in_current_token(&mut self, new_name: String) {
         match &mut self.current_token.as_mut().unwrap() {
             Token::StartTagToken { name, .. } => {
-                *name = new_name.into();
+                *name = new_name;
             }
             Token::EndTagToken { name, .. } => {
-                *name = new_name.into();
+                *name = new_name;
             }
             _ => panic!("trying to set the name of a non start/end tag token"),
         }

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -93,17 +93,17 @@ fn assert_token(have: Token, expected: &[Value], double_escaped: bool) {
             name,
             attributes,
             is_self_closing,
-        } => assert_starttag(expected, name, attributes, is_self_closing),
-        Token::EndTagToken { name, .. } => assert_endtag(expected, name, double_escaped),
-        Token::CommentToken { value } => assert_comment(expected, value, double_escaped),
-        Token::TextToken { value } => assert_text(expected, value, double_escaped),
+        } => assert_starttag(expected, &name, attributes, is_self_closing),
+        Token::EndTagToken { name, .. } => assert_endtag(expected, &name, double_escaped),
+        Token::CommentToken { value } => assert_comment(expected, &value, double_escaped),
+        Token::TextToken { value } => assert_text(expected, &value, double_escaped),
         Token::EofToken => panic!("expected eof token"),
     }
 }
 
 fn assert_starttag(
     expected: &[Value],
-    name: String,
+    name: &str,
     attributes: HashMap<String, String>,
     is_self_closing: bool,
 ) {
@@ -151,7 +151,7 @@ fn assert_starttag(
     assert_eq!(set1, set2, "attribute mismatch");
 }
 
-fn assert_comment(expected: &[Value], value: String, is_double_escaped: bool) {
+fn assert_comment(expected: &[Value], value: &str, is_double_escaped: bool) {
     let output_ref = expected.get(1).unwrap().as_str().unwrap();
     let output = if is_double_escaped {
         escape(output_ref)
@@ -162,7 +162,7 @@ fn assert_comment(expected: &[Value], value: String, is_double_escaped: bool) {
     assert_eq!(value, output, "incorrect text found in comment token");
 }
 
-fn assert_text(expected: &[Value], value: String, is_double_escaped: bool) {
+fn assert_text(expected: &[Value], value: &str, is_double_escaped: bool) {
     let output_ref = expected.get(1).unwrap().as_str().unwrap();
     let output = if is_double_escaped {
         escape(output_ref)
@@ -173,7 +173,7 @@ fn assert_text(expected: &[Value], value: String, is_double_escaped: bool) {
     assert_eq!(value, output, "incorrect text found in text token",);
 }
 
-fn assert_endtag(expected: &[Value], name: String, is_double_escaped: bool) {
+fn assert_endtag(expected: &[Value], name: &str, is_double_escaped: bool) {
     let output_ref = expected.get(1).unwrap().as_str().unwrap();
     let output = if is_double_escaped {
         escape(output_ref)


### PR DESCRIPTION
This PR
* Replaces `String` function arguments with the `&str` versions when possible
* Reduces the number of allocations
* Uses `String` for char buffers instead of `Vec<chr>`, since `String` is designed to be mutable and grow easily

In a perfect world, we'd have an allocation for the input, and then just move around the current buffer without allocating until DOM nodes are needed (so-called "zero copy").  But I'm not sure to what extent that's possible here or with a streaming parser.